### PR TITLE
Change grafana-sankey-plugin link

### DIFF
--- a/build/yamls/base/grafana.yml
+++ b/build/yamls/base/grafana.yml
@@ -107,7 +107,7 @@ spec:
           imagePullPolicy: IfNotPresent
           env:
             - name: GF_INSTALL_PLUGINS
-              value: "https://downloads.antrea.io/artifacts/grafana-custom-plugins/grafana-sankey-plugin-1.0.0.zip;theia-grafana-sankey-plugin,grafana-clickhouse-datasource 1.0.1"
+              value: "https://downloads.antrea.io/artifacts/grafana-custom-plugins/theia-grafana-sankey-plugin-1.0.0.zip;theia-grafana-sankey-plugin,grafana-clickhouse-datasource 1.0.1"
             - name: CLICKHOUSE_USERNAME
               valueFrom:
                 secretKeyRef: 

--- a/build/yamls/flow-visibility.yml
+++ b/build/yamls/flow-visibility.yml
@@ -4801,7 +4801,7 @@ spec:
       containers:
       - env:
         - name: GF_INSTALL_PLUGINS
-          value: https://downloads.antrea.io/artifacts/grafana-custom-plugins/grafana-sankey-plugin-1.0.0.zip;theia-grafana-sankey-plugin,grafana-clickhouse-datasource
+          value: https://downloads.antrea.io/artifacts/grafana-custom-plugins/theia-grafana-sankey-plugin-1.0.0.zip;theia-grafana-sankey-plugin,grafana-clickhouse-datasource
             1.0.1
         - name: CLICKHOUSE_USERNAME
           valueFrom:


### PR DESCRIPTION
  Rename grafana-sankey-plugin-1.0.0.zip to theia-grafana-sankey-plugin-1.0.0.zip,
  in order to differentiate "antreaflowvisibility-grafana-sankey-plugin" with
  "theia-grafana-sankey-plugin". The reason for keep the plugin link for
  "antreaflowvisibility-grafana-sankey-plugin" is that we need to keep the manifest
  in antrea v1.6 working.
  
  Signed-off-by: heanlan <hanlan@vmware.com>