### PR TITLE
Remove a redundant check in FA E2E test

### DIFF
--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -160,10 +160,6 @@ func TestFlowAggregator(t *testing.T) {
 	}
 	defer teardownTest(t, data)
 
-	if err != nil {
-		t.Fatalf("Error when creating Kubernetes utils client: %v", err)
-	}
-
 	podAIPs, podBIPs, podCIPs, podDIPs, podEIPs, err := createPerftestPods(data)
 	if err != nil {
 		t.Fatalf("Error when creating perftest Pods: %v", err)


### PR DESCRIPTION
Found a redundant error check in the Flow Aggregator E2E test.

Signed-off-by: Yongming Ding <dyongming@vmware.com>