### PR TITLE
Fix verify-doc workflow failure

### DIFF
--- a/.github/workflows/verify_docs.yml
+++ b/.github/workflows/verify_docs.yml
@@ -22,7 +22,7 @@ jobs:
       uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         folder-path: './docs'
-        file-path: './README.md, ./CHANGELOG.md, ./CONTRIBUTING.md, ./GOVERNANCE.md, ./MAINTAINERS.md, ./ROADMAP.md, ./SECURITY.md'
+        file-path: './README.md, ./CHANGELOG.md, ./CONTRIBUTING.md, ./GOVERNANCE.md, ./MAINTAINERS.md, ./SECURITY.md'
         config-file: 'hack/.md_links_config.json'
     - name: Markdownlint
       run: |


### PR DESCRIPTION
verify doc and spelling workflow consistently fails due to checking
on the unexisting ROADMAP.md file. We remove it from the check.
Example: https://github.com/antrea-io/theia/actions/runs/2383371105

Signed-off-by: heanlan <hanlan@vmware.com>