### PR TITLE
Support to disable Grafana in Theia Helm Chart

### DIFF
--- a/build/charts/theia/README.md
+++ b/build/charts/theia/README.md
@@ -19,11 +19,11 @@ Kubernetes: `>= 1.16.0-0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | clickhouse.connectionSecret | object | `{"password":"clickhouse_operator_password","username":"clickhouse_operator"}` | Credentials to connect to ClickHouse. They will be stored in a secret. |
-| clickhouse.image | object | `{"pullPolicy":"IfNotPresent","repository":"projects.registry.vmware.com/antrea/theia-clickhouse-server","tag":"21.11"}` | Container image to use for ClickHouse. |
+| clickhouse.image | object | `{"pullPolicy":"IfNotPresent","repository":"projects.registry.vmware.com/antrea/theia-clickhouse-server","tag":"21.11"}` | Container image used by ClickHouse. |
 | clickhouse.monitor.deletePercentage | float | `0.5` | The percentage of records in ClickHouse that will be deleted when the storage grows above threshold. Vary from 0 to 1. |
 | clickhouse.monitor.enable | bool | `true` | Determine whether to run a monitor to periodically check the ClickHouse memory usage and clean data. |
 | clickhouse.monitor.execInterval | string | `"1m"` | The time interval between two round of monitoring. Can be a plain integer using one of these unit suffixes ns, us (or µs), ms, s, m, h. |
-| clickhouse.monitor.image | object | `{"pullPolicy":"IfNotPresent","repository":"projects.registry.vmware.com/antrea/theia-clickhouse-monitor","tag":"latest"}` | Container image to use for the ClickHouse Monitor. |
+| clickhouse.monitor.image | object | `{"pullPolicy":"IfNotPresent","repository":"projects.registry.vmware.com/antrea/theia-clickhouse-monitor","tag":"latest"}` | Container image used by the ClickHouse Monitor. |
 | clickhouse.monitor.skipRoundsNum | int | `3` | The number of rounds for the monitor to stop after a deletion to wait for the ClickHouse MergeTree Engine to release memory. |
 | clickhouse.monitor.threshold | float | `0.5` | The storage percentage at which the monitor starts to delete old records. Vary from 0 to 1. |
 | clickhouse.service.httpPort | int | `8123` | TCP port number for the ClickHouse service. |
@@ -38,13 +38,14 @@ Kubernetes: `>= 1.16.0-0`
 | clickhouse.storage.size | string | `"8Gi"` | ClickHouse storage size. Can be a plain integer or as a fixed-point number using one of these quantity suffixes: E, P, T, G, M, K. Or the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki. |
 | clickhouse.ttl | string | `"1 HOUR"` | Time to live for data in the ClickHouse. Can be a plain integer using one of these unit suffixes SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, YEAR. |
 | grafana.dashboards | list | `["flow_records_dashboard.json","pod_to_pod_dashboard.json","pod_to_service_dashboard.json","pod_to_external_dashboard.json","node_to_node_dashboard.json","networkpolicy_dashboard.json"]` | The dashboards to be displayed in Grafana UI. The files must be put under  provisioning/dashboards |
-| grafana.image | object | `{"pullPolicy":"IfNotPresent","repository":"projects.registry.vmware.com/antrea/theia-grafana","tag":"8.3.3"}` | Container image to use for Grafana. |
+| grafana.enable | bool | `true` | Determine whether to install Grafana. It is used as a data visualization and monitoring tool.   |
+| grafana.image | object | `{"pullPolicy":"IfNotPresent","repository":"projects.registry.vmware.com/antrea/theia-grafana","tag":"8.3.3"}` | Container image used by Grafana. |
 | grafana.installPlugins | list | `["https://downloads.antrea.io/artifacts/grafana-custom-plugins/theia-grafana-sankey-plugin-1.0.0.zip;theia-grafana-sankey-plugin","https://downloads.antrea.io/artifacts/grafana-custom-plugins/theia-grafana-chord-plugin-1.0.0.zip;theia-grafana-chord-plugin","grafana-clickhouse-datasource 1.0.1"]` | Grafana plugins to install. |
 | grafana.loginSecret | object | `{"password":"admin","username":"admin"}` | Credentials to login to Grafana. They will be stored in a secret. |
 | grafana.service.tcpPort | int | `3000` | TCP port number for the Grafana service. |
 | grafana.service.type | string | `"NodePort"` | The type of Service exposing Grafana. It must be one of NodePort or LoadBalancer. |
-| sparkOperator.enable | bool | `false` | Install Spark Operator. It is required to run Network Policy Recommendation jobs. |
-| sparkOperator.image | object | `{"pullPolicy":"IfNotPresent","repository":"projects.registry.vmware.com/antrea/theia-spark-operator","tag":"v1beta2-1.3.3-3.1.1"}` | Container image to use for Spark Operator. |
+| sparkOperator.enable | bool | `false` | Determine whether to install Spark Operator. It is required to run Network Policy Recommendation jobs. |
+| sparkOperator.image | object | `{"pullPolicy":"IfNotPresent","repository":"projects.registry.vmware.com/antrea/theia-spark-operator","tag":"v1beta2-1.3.3-3.1.1"}` | Container image used by Spark Operator. |
 | sparkOperator.name | string | `"policy-recommendation"` | Name of Spark Operator. |
 
 ----------------------------------------------

--- a/build/charts/theia/templates/grafana/dashboard-configmap.yaml
+++ b/build/charts/theia/templates/grafana/dashboard-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enable }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,4 +8,5 @@ data:
 {{ $files := .Files }}
 {{- range $fileName := .Values.grafana.dashboards }}
 {{ tpl ($files.Glob (printf "provisioning/dashboards/%s" $fileName)).AsConfig $ | indent 2}}
+{{- end }}
 {{- end }}

--- a/build/charts/theia/templates/grafana/dashboard-provider-configmap.yaml
+++ b/build/charts/theia/templates/grafana/dashboard-provider-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enable }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
 data:
   dashboard_provider.yaml: |-
 {{ .Files.Get "provisioning/dashboards/dashboard_provider.yaml" | indent 4}}
+{{- end }}

--- a/build/charts/theia/templates/grafana/datasource-provider-configmap.yaml
+++ b/build/charts/theia/templates/grafana/datasource-provider-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enable }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
 data:
   datasource_provider.yaml: |-
 {{ tpl (.Files.Get "provisioning/datasources/datasource_provider.yaml") . | indent 4}}
+{{- end }}

--- a/build/charts/theia/templates/grafana/deployment.yaml
+++ b/build/charts/theia/templates/grafana/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enable }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -98,3 +99,4 @@ spec:
         - name: grafana-dashboard-config
           configMap:
             name: grafana-dashboard-config
+{{- end }}

--- a/build/charts/theia/templates/grafana/persistentvolume.yaml
+++ b/build/charts/theia/templates/grafana/persistentvolume.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enable }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -10,3 +11,4 @@ spec:
     - ReadWriteOnce
   hostPath:
     path: "/data/grafana"
+{{- end }}

--- a/build/charts/theia/templates/grafana/persistentvolumeclaim.yaml
+++ b/build/charts/theia/templates/grafana/persistentvolumeclaim.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enable }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -10,3 +11,4 @@ spec:
   resources:
     requests:
       storage: 1Gi
+{{- end }}

--- a/build/charts/theia/templates/grafana/role.yaml
+++ b/build/charts/theia/templates/grafana/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enable }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -14,3 +15,4 @@ rules:
       - get
       - list
       - watch
+{{- end }}

--- a/build/charts/theia/templates/grafana/rolebinding.yaml
+++ b/build/charts/theia/templates/grafana/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enable }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -13,3 +14,4 @@ subjects:
   - kind: ServiceAccount
     name: grafana
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/build/charts/theia/templates/grafana/secret.yaml
+++ b/build/charts/theia/templates/grafana/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enable }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ type: Opaque
 stringData:
   admin-username: {{ .Values.grafana.loginSecret.username }}
   admin-password: {{ .Values.grafana.loginSecret.password }}
+{{- end }}

--- a/build/charts/theia/templates/grafana/service.yaml
+++ b/build/charts/theia/templates/grafana/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enable }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,3 +13,4 @@ spec:
     app: grafana
   sessionAffinity: None
   type: {{ .Values.grafana.service.type }}
+{{- end }}

--- a/build/charts/theia/templates/grafana/serviceaccount.yaml
+++ b/build/charts/theia/templates/grafana/serviceaccount.yaml
@@ -1,5 +1,7 @@
+{{- if .Values.grafana.enable }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grafana
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/build/charts/theia/templates/grafana/storageclass.yaml
+++ b/build/charts/theia/templates/grafana/storageclass.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enable }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -6,3 +7,4 @@ provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 allowVolumeExpansion: True
+{{- end }}

--- a/build/charts/theia/values.yaml
+++ b/build/charts/theia/values.yaml
@@ -1,5 +1,5 @@
 clickhouse:
-  # -- Container image to use for ClickHouse.
+  # -- Container image used by ClickHouse.
   image: 
     repository: "projects.registry.vmware.com/antrea/theia-clickhouse-server"
     pullPolicy: "IfNotPresent"
@@ -20,7 +20,7 @@ clickhouse:
     # -- The number of rounds for the monitor to stop after a deletion to wait for
     # the ClickHouse MergeTree Engine to release memory.
     skipRoundsNum: 3
-    # -- Container image to use for the ClickHouse Monitor.
+    # -- Container image used by the ClickHouse Monitor.
     image:
       repository: "projects.registry.vmware.com/antrea/theia-clickhouse-monitor"
       pullPolicy: "IfNotPresent"
@@ -71,7 +71,9 @@ clickhouse:
       # storageClassName: ""
       # volumeName: ""
 grafana:
-  # -- Container image to use for Grafana.
+  # -- Determine whether to install Grafana. It is used as a data visualization and monitoring tool.  
+  enable: true
+  # -- Container image used by Grafana.
   image: 
     repository: "projects.registry.vmware.com/antrea/theia-grafana"
     pullPolicy: "IfNotPresent"
@@ -100,11 +102,11 @@ grafana:
     - node_to_node_dashboard.json
     - networkpolicy_dashboard.json
 sparkOperator:
-  # -- Install Spark Operator. It is required to run Network Policy Recommendation jobs.
+  # -- Determine whether to install Spark Operator. It is required to run Network Policy Recommendation jobs.
   enable: false
   # -- Name of Spark Operator.
   name: "policy-recommendation"
-  # -- Container image to use for Spark Operator.
+  # -- Container image used by Spark Operator.
   image: 
     repository: "projects.registry.vmware.com/antrea/theia-spark-operator"
     pullPolicy: "IfNotPresent"

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -25,6 +25,7 @@ Generate a YAML manifest for the Clickhouse-Grafana Flow-visibility Solution, us
 Kustomize, and print it to stdout.
         --mode (dev|release)  Choose the configuration variant that you need (default is 'dev')
         --spark-operator      Generate a manifest with Spark Operator enabled.
+        --no-grafana          Generate a manifest with Grafana disabled.
 This tool uses Helm 3 (https://helm.sh/) and Kustomize (https://github.com/kubernetes-sigs/kustomize)
 to generate manifests for Antrea. You can set the HELM and KUSTOMIZE environment variable to
 the path of the helm and kustomize binary you want us to use. Otherwise we will download the
@@ -41,6 +42,7 @@ function print_help {
 
 MODE="dev"
 SPARK_OP=false
+GRAFANA=true
 
 while [[ $# -gt 0 ]]
 do
@@ -53,6 +55,10 @@ case $key in
     ;;
     --spark-operator)
     SPARK_OP=true
+    shift 1
+    ;;
+    --no-grafana)
+    GRAFANA=false
     shift 1
     ;;
     -h|--help)
@@ -113,6 +119,9 @@ if [ "$MODE" == "release" ]; then
 fi
 if $SPARK_OP; then
     HELM_VALUES+=("sparkOperator.enable=true")
+fi
+if [ "$GRAFANA" == false ]; then
+    HELM_VALUES+=("grafana.enable=false")
 fi
 
 delim=""


### PR DESCRIPTION
Grafana is not used when we run e2e tests or focus on NP Recommendation development.
Having an option to disable it can provide a more light-weighted development in some cases.

Signed-off-by: Yanjun Zhou <zhouya@vmware.com>