### PR TITLE
Export Pod logs when TestMain fails at deploying Antrea

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -98,6 +98,7 @@ func testMain(m *testing.M) int {
 	log.Printf("Num nodes: %d", clusterInfo.numNodes)
 	err = ensureAntreaRunning(testData)
 	if err != nil {
+		exportLogs(&testing.T{}, testData, "beforeTeardown", true, true)
 		log.Fatalf("Error when deploying Antrea: %v", err)
 	}
 	if err != nil {


### PR DESCRIPTION
This commit adds the Pods log exporting process to TestMain. The
major motivation is to help triage when the Antrea controller or
Antrea agent Pods fail to start.

Signed-off-by: heanlan <hanlan@vmware.com>