### PR TITLE
Improvement on the policy recommendation status command

### DIFF
--- a/pkg/theia/commands/policy_recommendation.go
+++ b/pkg/theia/commands/policy_recommendation.go
@@ -34,10 +34,15 @@ Must specify a subcommand like run, status or retrieve.`,
 
 func init() {
 	rootCmd.AddCommand(policyRecommendationCmd)
-	rootCmd.PersistentFlags().StringP(
-		"kubeconfig",
-		"k",
+	policyRecommendationCmd.PersistentFlags().String(
+		"clickhouse-endpoint",
 		"",
-		"absolute path to the k8s config file, will use $KUBECONFIG if not specified",
+		"The ClickHouse Service endpoint.",
+	)
+	policyRecommendationCmd.PersistentFlags().Bool(
+		"use-cluster-ip",
+		false,
+		`Enable this option will use ClusterIP instead of port forwarding when connecting to the ClickHouse Service
+and Spark Monitoring Service. It can only be used when running in cluster.`,
 	)
 }

--- a/pkg/theia/commands/policy_recommendation_run.go
+++ b/pkg/theia/commands/policy_recommendation_run.go
@@ -456,17 +456,6 @@ Example values include 512M, 1G, 8G, etc.`,
 		false,
 		"Enable this option will hold and wait the whole policy recommendation job finishes.",
 	)
-	policyRecommendationRunCmd.Flags().String(
-		"clickhouse-endpoint",
-		"",
-		"The ClickHouse Service endpoint. It can only be used when wait is enabled.",
-	)
-	policyRecommendationRunCmd.Flags().Bool(
-		"use-cluster-ip",
-		false,
-		`Enable this option will use ClusterIP instead of port forwarding when connecting to the ClickHouse Service.
-It can only be used when running in cluster and when wait is enabled.`,
-	)
 	policyRecommendationRunCmd.Flags().StringP(
 		"file",
 		"f",

--- a/pkg/theia/commands/root.go
+++ b/pkg/theia/commands/root.go
@@ -53,4 +53,10 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().IntVarP(&verbose, "verbose", "v", 0, "set verbose level")
+	rootCmd.PersistentFlags().StringP(
+		"kubeconfig",
+		"k",
+		"",
+		"absolute path to the k8s config file, will use $KUBECONFIG if not specified",
+	)
 }


### PR DESCRIPTION
In this commit, we are adding the following improvements on the policy
recommendation status command:
1. Check the ClickHouse DB for the completed jobs which are no longer on
   the API server.
2. Show the error message for the failed jobs.
3. Replace the empty state string with NEW for the jobs on NewState