### PR TITLE
Fix Docker image tags for released Helm charts

### DIFF
--- a/build/charts/theia/Chart.yaml
+++ b/build/charts/theia/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 displayName: Theia
 home: https://antrea.io/
 version: 0.0.0
-appVersion: 0.0.0
+appVersion: latest
 kubeVersion: ">= 1.16.0-0"
 icon: https://raw.githubusercontent.com/antrea-io/antrea/main/docs/assets/logo/antrea_logo.svg
 description: Antrea Network Flow Visibility

--- a/build/charts/theia/README.md
+++ b/build/charts/theia/README.md
@@ -1,6 +1,6 @@
 # theia
 
-![Version: 0.2.0-dev](https://img.shields.io/badge/Version-0.2.0--dev-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0-dev](https://img.shields.io/badge/AppVersion-0.2.0--dev-informational?style=flat-square)
+![Version: 0.2.0-dev](https://img.shields.io/badge/Version-0.2.0--dev-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Antrea Network Flow Visibility
 
@@ -23,7 +23,7 @@ Kubernetes: `>= 1.16.0-0`
 | clickhouse.monitor.deletePercentage | float | `0.5` | The percentage of records in ClickHouse that will be deleted when the storage grows above threshold. Vary from 0 to 1. |
 | clickhouse.monitor.enable | bool | `true` | Determine whether to run a monitor to periodically check the ClickHouse memory usage and clean data. |
 | clickhouse.monitor.execInterval | string | `"1m"` | The time interval between two round of monitoring. Can be a plain integer using one of these unit suffixes ns, us (or µs), ms, s, m, h. |
-| clickhouse.monitor.image | object | `{"pullPolicy":"IfNotPresent","repository":"projects.registry.vmware.com/antrea/theia-clickhouse-monitor","tag":"latest"}` | Container image used by the ClickHouse Monitor. |
+| clickhouse.monitor.image | object | `{"pullPolicy":"IfNotPresent","repository":"projects.registry.vmware.com/antrea/theia-clickhouse-monitor","tag":""}` | Container image used by the ClickHouse Monitor. |
 | clickhouse.monitor.skipRoundsNum | int | `3` | The number of rounds for the monitor to stop after a deletion to wait for the ClickHouse MergeTree Engine to release memory. |
 | clickhouse.monitor.threshold | float | `0.5` | The storage percentage at which the monitor starts to delete old records. Vary from 0 to 1. |
 | clickhouse.service.httpPort | int | `8123` | TCP port number for the ClickHouse service. |

--- a/build/charts/theia/templates/clickhouse/clickhouseinstallation.yaml
+++ b/build/charts/theia/templates/clickhouse/clickhouseinstallation.yaml
@@ -49,7 +49,7 @@ spec:
                 {{- end }}
             {{- if .Values.clickhouse.monitor.enable}}
             - name: clickhouse-monitor
-              image: {{ .Values.clickhouse.monitor.image.repository }}:{{ .Values.clickhouse.monitor.image.tag }}
+              image: {{ .Values.clickhouse.monitor.image.repository }}:{{ default .Chart.AppVersion .Values.clickhouse.monitor.image.tag }}
               imagePullPolicy: {{ .Values.clickhouse.monitor.image.pullPolicy }}
               env:
                 - name: CLICKHOUSE_USERNAME

--- a/build/charts/theia/values.yaml
+++ b/build/charts/theia/values.yaml
@@ -24,7 +24,7 @@ clickhouse:
     image:
       repository: "projects.registry.vmware.com/antrea/theia-clickhouse-monitor"
       pullPolicy: "IfNotPresent"
-      tag: "latest"
+      tag: ""
   # -- Credentials to connect to ClickHouse. They will be stored in a secret.
   connectionSecret:
     username : "clickhouse_operator"


### PR DESCRIPTION
The ClickHouse monitor image tag is always set to "latest" when we release
the Helm chart. This PR fixes the inconsistency between the ClickHouse monitor
image tag and the released chart version.
This fix is inspired by https://github.com/antrea-io/antrea/pull/3990.

Signed-off-by: Yanjun Zhou <zhouya@vmware.com>