### PR TITLE
Improve Policy Recommendation e2e test

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -29,10 +29,26 @@ jobs:
     outputs:
       has_changes: ${{ steps.check_diff.outputs.has_changes }}
 
-  test-e2e-encap:
-    name: E2e tests on a Kind cluster on Linux
+  build-policy-recommendation-image:
+    name: Build Policy Recommendation image to be used for Kind e2e tests
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' }}
+    runs-on: [ ubuntu-latest ]
+    steps:
+    - uses: actions/checkout@v3
+    - run: make policy-recommendation
+    - name: Save Policy Recommendation image to tarball
+      run: docker save -o policy-recommendation.tar antrea/theia-policy-recommendation
+    - name: Upload Policy Recommendation image for subsequent jobs
+      uses: actions/upload-artifact@v3
+      with:
+        name: policy-recommendation
+        path: policy-recommendation.tar
+        retention-days: 1 # minimum value, in case artifact deletion by 'artifact-cleanup' job fails
+
+  test-e2e-encap:
+    name: E2e tests on a Kind cluster on Linux
+    needs: build-policy-recommendation-image
     runs-on: [ubuntu-latest]
     steps:
       - name: Free disk space
@@ -44,6 +60,12 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.17
+      - name: Download Theia images from previous jobs
+        uses: actions/download-artifact@v3
+      - name: Load Theia image
+        run:  |
+          docker load -i policy-recommendation/policy-recommendation.tar
+          docker tag antrea/theia-policy-recommendation:latest projects.registry.vmware.com/antrea/theia-policy-recommendation:latest
       - name: Install Kind
         run: |
           curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
@@ -63,3 +85,19 @@ jobs:
           name: e2e-kind-fa.tar.gz
           path: log.tar.gz
           retention-days: 30
+
+  # Runs after all other jobs in the workflow and deletes Theia Docker images uploaded as temporary
+  # artifacts. It uses a third-party, MIT-licensed action (geekyeggo/delete-artifact). While Github
+  # exposes an API for deleting artifacts, they do not support an official delete-artifact action
+  # yet.
+  artifact-cleanup:
+    name: Delete uploaded images
+    needs: [build-policy-recommendation-image, test-e2e-encap]
+    if: ${{ always() && needs.build-policy-recommendation-image.result == 'success' }}
+    runs-on: [ubuntu-latest]
+    steps:
+    - name: Delete policy-recommendation
+      if: ${{ needs.build-policy-recommendation-image.result == 'success' }}
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: policy-recommendation

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -62,9 +62,11 @@ jobs:
           go-version: 1.17
       - name: Download Theia images from previous jobs
         uses: actions/download-artifact@v3
+        with:
+          name: policy-recommendation
       - name: Load Theia image
         run:  |
-          docker load -i policy-recommendation/policy-recommendation.tar
+          docker load -i policy-recommendation.tar
           docker tag antrea/theia-policy-recommendation:latest projects.registry.vmware.com/antrea/theia-policy-recommendation:latest
       - name: Install Kind
         run: |

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -345,15 +345,15 @@ function deliver_antrea {
     (cd $GIT_CHECKOUT_DIR && make theia-linux)
     ${SCP_WITH_ANTREA_CI_KEY} $GIT_CHECKOUT_DIR/bin/theia-linux capv@${control_plane_ip}:~/theia
 
-
     # copy images
     docker pull projects.registry.vmware.com/antrea/antrea-ubuntu:latest
     docker pull projects.registry.vmware.com/antrea/flow-aggregator:latest
     docker pull projects.registry.vmware.com/antrea/theia-spark-operator:v1beta2-1.3.3-3.1.1
-    docker pull projects.registry.vmware.com/antrea/theia-policy-recommendation:latest
     docker save -o antrea-ubuntu.tar projects.registry.vmware.com/antrea/antrea-ubuntu:latest
     docker save -o flow-aggregator.tar projects.registry.vmware.com/antrea/flow-aggregator:latest
     docker save -o theia-spark-operator.tar projects.registry.vmware.com/antrea/theia-spark-operator:v1beta2-1.3.3-3.1.1
+
+    (cd $GIT_CHECKOUT_DIR && make policy-recommendation)
     docker save -o theia-policy-recommendation.tar projects.registry.vmware.com/antrea/theia-policy-recommendation:latest
 
     # not sure the exact image tag, so read from yaml

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -113,8 +113,7 @@ COMMON_IMAGES_LIST=("k8s.gcr.io/e2e-test-images/agnhost:2.29" \
                     "projects.registry.vmware.com/antrea/theia-clickhouse-server:21.11" \
                     "projects.registry.vmware.com/antrea/theia-clickhouse-monitor:latest" \
                     "projects.registry.vmware.com/antrea/theia-grafana:8.3.3" \
-                    "projects.registry.vmware.com/antrea/theia-spark-operator:v1beta2-1.3.3-3.1.1" \
-                    "projects.registry.vmware.com/antrea/theia-policy-recommendation:latest")
+                    "projects.registry.vmware.com/antrea/theia-spark-operator:v1beta2-1.3.3-3.1.1")
 
 for image in "${COMMON_IMAGES_LIST[@]}"; do
     for i in `seq 3`; do
@@ -123,6 +122,7 @@ for image in "${COMMON_IMAGES_LIST[@]}"; do
     done
 done
 
+COMMON_IMAGES_LIST+=("projects.registry.vmware.com/antrea/theia-policy-recommendation:latest")
 printf -v COMMON_IMAGES "%s " "${COMMON_IMAGES_LIST[@]}"
 
 function setup_cluster {

--- a/test/e2e/flowvisibility_test.go
+++ b/test/e2e/flowvisibility_test.go
@@ -176,7 +176,6 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	if err != nil {
 		failOnError(fmt.Errorf("error when creating perftest Services: %v", err), t, data)
 	}
-	defer deletePerftestServices(t, data)
 	// Wait for the Service to be realized.
 	time.Sleep(3 * time.Second)
 
@@ -1178,15 +1177,6 @@ func createPerftestServices(data *TestData, isIPv6 bool) (svcB *corev1.Service, 
 	}
 
 	return svcB, svcC, nil
-}
-
-func deletePerftestServices(t *testing.T, data *TestData) {
-	for _, serviceName := range []string{"perftest-b", "perftest-c"} {
-		err := data.deleteService(testNamespace, serviceName)
-		if err != nil {
-			t.Logf("Error when deleting %s Service: %v", serviceName, err)
-		}
-	}
 }
 
 // getBandwidthAndPorts parses iperf commands output and returns bandwidth,

--- a/test/e2e/flowvisibility_test.go
+++ b/test/e2e/flowvisibility_test.go
@@ -176,8 +176,6 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	if err != nil {
 		failOnError(fmt.Errorf("error when creating perftest Services: %v", err), t, data)
 	}
-	// Wait for the Service to be realized.
-	time.Sleep(3 * time.Second)
 
 	// IntraNodeFlows tests the case, where Pods are deployed on same Node
 	// and their flow information is exported as IPFIX flow records.

--- a/test/e2e/policyrecommendation_test.go
+++ b/test/e2e/policyrecommendation_test.go
@@ -81,7 +81,6 @@ func TestPolicyRecommendation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error when creating perftest-b Service: %v", err)
 	}
-	defer deleteTestService(t, data)
 	// Wait for the Service to be realized.
 	time.Sleep(3 * time.Second)
 	// In dual stack cluster, Service IP can be assigned as different IP family from specified.
@@ -103,9 +102,10 @@ func TestPolicyRecommendation(t *testing.T) {
 
 	if v4Enabled {
 		srcIP := podAIPs.ipv4.String()
+		dstIP := podBIPs.ipv4.String()
 		testFlowPodToPod := testFlow{
 			srcIP:      srcIP,
-			dstIP:      podBIPs.ipv4.String(),
+			dstIP:      dstIP,
 			srcPodName: "perftest-a",
 			dstPodName: "perftest-b",
 		}
@@ -247,7 +247,7 @@ func testPolicyRecommendationFailed(t *testing.T, data *TestData) {
 	})
 	require.NoError(t, err)
 	assert := assert.New(t)
-	assert.Containsf(stdout, "Error message: driver", "stdout: %s", stdout)
+	assert.Truef(strings.Contains(stdout, "Error message: driver pod not found") || strings.Contains(stdout, "Error message: driver container failed"), "stdout: %s", stdout)
 }
 
 // Example output:
@@ -448,11 +448,4 @@ func createTestService(data *TestData, isIPv6 bool) (svcB *corev1.Service, err e
 	}
 
 	return svcB, nil
-}
-
-func deleteTestService(t *testing.T, data *TestData) {
-	err := data.deleteService(testNamespace, "perftest-b")
-	if err != nil {
-		t.Logf("Error when deleting perftest-b Service: %v", err)
-	}
 }

--- a/test/e2e/policyrecommendation_test.go
+++ b/test/e2e/policyrecommendation_test.go
@@ -81,8 +81,6 @@ func TestPolicyRecommendation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error when creating perftest-b Service: %v", err)
 	}
-	// Wait for the Service to be realized.
-	time.Sleep(3 * time.Second)
 	// In dual stack cluster, Service IP can be assigned as different IP family from specified.
 	// In that case, source IP and destination IP will align with IP family of Service IP.
 	// For IPv4-only and IPv6-only cluster, IP family of Service IP will be same as Pod IPs.
@@ -444,7 +442,7 @@ func createTestService(data *TestData, isIPv6 bool) (svcB *corev1.Service, err e
 
 	svcB, err = data.CreateService("perftest-b", testNamespace, iperfPort, iperfPort, map[string]string{"antrea-e2e": "perftest-b"}, false, false, corev1.ServiceTypeClusterIP, &svcIPFamily)
 	if err != nil {
-		return nil, fmt.Errorf("Error when creating perftest-b Service: %v", err)
+		return nil, fmt.Errorf("error when creating perftest-b Service: %v", err)
 	}
 
 	return svcB, nil


### PR DESCRIPTION
Fix #72 

In this commit, we add these improvements for the Policy Recommendation
e2e test:
1. Add a test case for the failed policy recommendation job.
2. Add policy recommendation check for the Pod-to-Svc and Pod-to-External flows.
3. Change the Kind/Jenkins test script to build the latest policy
   recommendation image for testing, instead of pulling from Docker.

Signed-off-by: Yongming Ding <dyongming@vmware.com>