### PR TITLE
Add some artifacthub.io annotations to Helm charts

### DIFF
--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -11,8 +11,7 @@ on:
     - release-*
     - feature/*
   release:
-    types:
-      - created
+    types: [published]
 
 jobs:
   check-changes:

--- a/.github/workflows/process_release.yml
+++ b/.github/workflows/process_release.yml
@@ -2,8 +2,7 @@ name: Process new release
 
 on:
   release:
-    types:
-      - created
+    types: [published]
 
 jobs:
   upload-release-assets:
@@ -17,6 +16,7 @@ jobs:
     - name: Build assets
       env:
         TAG: ${{ github.ref }}
+        PRERELEASE: ${{ github.event.release.prerelease }}
       run: |
         mkdir assets
         VERSION="${TAG:10}" ./hack/release/prepare-assets.sh ./assets

--- a/build/charts/theia/Chart.yaml
+++ b/build/charts/theia/Chart.yaml
@@ -21,3 +21,7 @@ keywords:
   - Flow visibility
 sources:
   - https://github.com/antrea-io/theia
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/operator: "false"
+  artifacthub.io/prerelease: "false"

--- a/hack/generate-helm-release.sh
+++ b/hack/generate-helm-release.sh
@@ -89,5 +89,11 @@ elif ! $HELM version > /dev/null 2>&1; then
 fi
 
 THEIA_CHART="$THIS_DIR/../build/charts/theia"
+# create a backup file before making changes.
+# note that the backup file will not be included in the release: .bak files are
+# ignored as per the .helmignore file.
+cp "$THEIA_CHART/Chart.yaml" "$THEIA_CHART/Chart.yaml.bak"
+yq -i '.annotations."artifacthub.io/prerelease" = strenv(PRERELEASE)' "$THEIA_CHART/Chart.yaml"
 $HELM package --app-version $VERSION --version $VERSION $THEIA_CHART
 mv "theia-$VERSION.tgz" "$OUT/theia-chart.tgz"
+mv "$THEIA_CHART/Chart.yaml.bak" "$THEIA_CHART/Chart.yaml"

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -17,6 +17,9 @@
 # This script generates all the assets required for an Antrea Github release to
 # the provided directory.
 # Usage: VERSION=v1.0.0 ./prepare-assets.sh <output dir>
+# In addition to the VERSION environment variable (which is required), the
+# PRERELEASE environment variable can also be set to true or false (it will
+# default to false).
 
 set -eo pipefail
 
@@ -32,6 +35,12 @@ fi
 if [ -z "$1" ]; then
     echoerr "Argument required: output directory for assets"
 fi
+
+: "${PRERELEASE:=false}"
+if [ "$PRERELEASE" != "true" ] && [ "$PRERELEASE" != "false" ]; then
+    echoerr "Environment variable PRERELEASE should only be set to 'true' or 'false'"
+fi
+export PRERELEASE
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 


### PR DESCRIPTION
This PR adds some annotation as suggested at https://artifacthub.io/docs/topics/annotations/helm/.
This is added to be synchronized with  Antrea.
Refer to https://github.com/antrea-io/antrea/pull/4003

Signed-off-by: Yanjun Zhou <zhouya@vmware.com>