### PR TITLE
Update clickhouse server repo in GitHub workflow

### DIFF
--- a/.github/workflows/docker_update_theia.yml
+++ b/.github/workflows/docker_update_theia.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Push antrea/theia-clickhouse-server
         uses: akhilerm/tag-push-action@v2.0.0
         with:
-          src: docker.io/yandex/clickhouse-server:${{ github.event.inputs.ch-server-tag }}
+          src: docker.io/clickhouse/clickhouse-server:${{ github.event.inputs.ch-server-tag }}
           dst: |
             docker.io/antrea/theia-clickhouse-server:${{ github.event.inputs.ch-server-tag }}
       - name: Push antrea/theia-spark-operator


### PR DESCRIPTION
yandex/clickhouse-server is stale for 6 months now and the new repo is clickhouse/clickhouse-server:
https://hub.docker.com/r/clickhouse/clickhouse-server/tags

Given that current version we use (21.11) is no longer supported in term of security updates:
https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md
this change updates the workflow with the new repo to allow updating to later versions of the server in case we want to. The new repo still contains the current tag.