### PR TITLE
Remove Antrea FOSSA link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,3 @@ information.
 ## License
 
 Theia is licensed under the [Apache License, version 2.0](LICENSE)
-
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fantrea-io%2Fantrea.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fantrea-io%2Fantrea?ref=badge_large)


### PR DESCRIPTION
The link is for the "antrea" repo.

Signed-off-by: Jianjun Shen <shenj@vmware.com>