### PR TITLE
Remove broken markdown links from doc

### DIFF
--- a/.github/workflows/verify_docs.yml
+++ b/.github/workflows/verify_docs.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Checking for broken Markdown links for main branch
       uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
-        folder-path: './docs'
-        file-path: './README.md, ./CHANGELOG.md, ./CONTRIBUTING.md, ./GOVERNANCE.md, ./MAINTAINERS.md, ./SECURITY.md'
+        folder-path: './docs, ./CHANGELOG'
+        file-path: './README.md, ./CONTRIBUTING.md, ./GOVERNANCE.md, ./MAINTAINERS.md, ./SECURITY.md'
         config-file: 'hack/.md_links_config.json'
     - name: Markdownlint
       run: |

--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -657,15 +657,14 @@ and throughput is shown in the line graphs.
 
 Network-Policy Flows Dashboard visualizes the traffic with NetworkPolicies enforced.
 The Chord diagram visualizes the cumulative bytes of all the traffic in the selected
-time range. We use green color ![#228B22](https://via.placeholder.com/15/228B22/000000?text=+)
-to highlight traffic with "Allow" NetworkPolicy enforced, red color
-![#EE4B2B](https://via.placeholder.com/15/EE4B2B/000000?text=+) to highlight
-traffic with "Deny" NetworkPolicy enforced. Specifically, "Deny" NetworkPolicy
-refers to NetworkPolicy with egressNetworkPolicyRuleAction or
-ingressNetworkPolicyRuleAction set to `Drop` or `Reject`. Unprotected traffic
-without NetworkPolicy enforced has the same color with its source Pod. Every
-link is in the shape of an arrow, pointing from source to destination. Line
-graphs show the evolution of traffic throughput with NetworkPolicy enforced.
+time range. We use green color to highlight traffic with "Allow" NetworkPolicy
+enforced, red color to highlight traffic with "Deny" NetworkPolicy enforced.
+Specifically, "Deny" NetworkPolicy refers to NetworkPolicy with
+egressNetworkPolicyRuleAction or ingressNetworkPolicyRuleAction set to `Drop`
+or `Reject`. Unprotected traffic without NetworkPolicy enforced has the same
+color with its source Pod. Every link is in the shape of an arrow, pointing
+from source to destination. Line graphs show the evolution of traffic throughput
+with NetworkPolicy enforced.
 
 <img src="https://downloads.antrea.io/static/05232022/flow-visibility-np-0.png" width="900" alt="Network-Policy Flows Dashboard">
 

--- a/hack/.md_links_config.json
+++ b/hack/.md_links_config.json
@@ -26,9 +26,6 @@
         },
         {
             "pattern": "https://www.virtualbox.org/*"
-        },
-        {
-            "pattern": "https://via.placeholder.com/*"
         }
     ],
     "retryOn429": false,


### PR DESCRIPTION
GitHub Markdown stop rendering the color block we have been using
in the network-flow-visibility.md. We remove those links in this PR.

Signed-off-by: heanlan <hanlan@vmware.com>