### PR TITLE
Fix ClickHouse monitor image tag when releasing

### DIFF
--- a/build/charts/theia/templates/_helpers.tpl
+++ b/build/charts/theia/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{- $clickhouse := .clickhouse }}
 {{- $version := .version }}
 - name: clickhouse-monitor
-  image: {{ $clickhouse.monitor.image.repository }}:{{ default $version $clickhouse.monitor.image.tag }}
+  image: {{ include "clickHouseMonitorImage" . | quote }}
   imagePullPolicy: {{ $clickhouse.monitor.image.pullPolicy }}
   env:
     - name: CLICKHOUSE_USERNAME
@@ -79,3 +79,17 @@
     sizeLimit: {{ $clickhouse.storage.size }}
 {{- end }}
 {{- end }}
+
+{{- define "clickHouseMonitorImageTag" -}}
+{{- if .clickhouse.monitor.image.tag }}
+{{- .clickhouse.monitor.image.tag -}}
+{{- else if eq .version "latest" }}
+{{- print "latest" -}}
+{{- else }}
+{{- print "v" .version -}}
+{{- end }}
+{{- end -}}
+
+{{- define "clickHouseMonitorImage" -}}
+{{- print .clickhouse.monitor.image.repository ":" (include "clickHouseMonitorImageTag" .) -}}
+{{- end -}}

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -133,10 +133,10 @@ HELM_VALUES=()
 HELM_VALUES+=("clickhouse.storage.size=$CH_SIZE" "clickhouse.monitor.threshold=$CH_THRESHOLD")
 
 if [ "$MODE" == "dev" ] && [ -n "$IMG_NAME" ]; then
-    HELM_VALUES+=("clickhouse.monitorImage.repository=$IMG_NAME")
+    HELM_VALUES+=("clickhouse.monitor.image.repository=$IMG_NAME")
 fi
 if [ "$MODE" == "release" ]; then
-    HELM_VALUES+=("clickhouse.monitorImage.repository=$IMG_NAME" "clickhouse.monitorImage.tag=$IMG_TAG")
+    HELM_VALUES+=("clickhouse.monitor.image.repository=$IMG_NAME" "clickhouse.monitor.image.tag=$IMG_TAG")
 fi
 if [ "$MODE" == "antrea-e2e" ]; then
     HELM_VALUES+=("grafana.enable=false" "clickhouse.monitor.enable=false")


### PR DESCRIPTION
This PR is inspired by https://github.com/antrea-io/antrea/pull/4138 and fixes the issue https://github.com/antrea-io/antrea/issues/4137.

- It adds the missing leading `v` for ClickHouse monitor image tag in the
  released Helm chart. 
- It also fixes the wrong ClickHouse monitor image tag when generating
 `flow-visibiltiy.yaml` for release.

Signed-off-by: Yanjun Zhou <zhouya@vmware.com>