### PR TITLE
Updated theia-clickhouse-server image for arm64 support

### DIFF
--- a/build/yamls/flow-visibility.yml
+++ b/build/yamls/flow-visibility.yml
@@ -5215,7 +5215,7 @@ spec:
         - env:
           - name: THEIA_VERSION
             value: 0.3.0
-          image: projects.registry.vmware.com/antrea/theia-clickhouse-server:21.11
+          image: projects.registry.vmware.com/antrea/theia-clickhouse-server:22.6
           imagePullPolicy: IfNotPresent
           name: clickhouse
           volumeMounts:


### PR DESCRIPTION
This commit adds updated directions to network-flow-visibility.md for deploying
through standalone manifest. Arm64 architecture requires an updated image for
theia-clickhouse-server.

Signed-off-by: Dhruv Jain <dhruvj@vmware.com>