### PR TITLE
Fix placeholder errors in ClickHouse monitor

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -45,10 +45,29 @@ jobs:
         name: policy-recommendation
         path: policy-recommendation.tar
         retention-days: 1 # minimum value, in case artifact deletion by 'artifact-cleanup' job fails
+  
+  build-clickhouse-monitor-image:
+    name: Build ClickHouse monitor image to be used for Kind e2e tests
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.has_changes == 'yes' }}
+    runs-on: [ ubuntu-latest ]
+    steps:
+    - uses: actions/checkout@v3
+    - run: make clickhouse-monitor
+    - name: Save ClickHouse monitor image to tarball
+      run: docker save -o clickhouse-monitor.tar antrea/theia-clickhouse-monitor
+    - name: Upload ClickHouse monitor image for subsequent jobs
+      uses: actions/upload-artifact@v3
+      with:
+        name: clickhouse-monitor
+        path: clickhouse-monitor.tar
+        retention-days: 1 # minimum value, in case artifact deletion by 'artifact-cleanup' job fails
 
   test-e2e-encap:
     name: E2e tests on a Kind cluster on Linux
-    needs: build-policy-recommendation-image
+    needs: 
+      - build-policy-recommendation-image
+      - build-clickhouse-monitor-image
     runs-on: [ubuntu-latest]
     steps:
       - name: Free disk space
@@ -60,14 +79,20 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
-      - name: Download Theia images from previous jobs
+      - name: Download Policy Recommendation images from previous jobs
         uses: actions/download-artifact@v3
         with:
           name: policy-recommendation
+      - name: Download ClickHouse monitor images from previous jobs
+        uses: actions/download-artifact@v3
+        with:
+          name: clickhouse-monitor
       - name: Load Theia image
         run:  |
           docker load -i policy-recommendation.tar
           docker tag antrea/theia-policy-recommendation:latest projects.registry.vmware.com/antrea/theia-policy-recommendation:latest
+          docker load -i clickhouse-monitor.tar
+          docker tag antrea/theia-clickhouse-monitor:latest projects.registry.vmware.com/antrea/theia-clickhouse-monitor:latest
       - name: Install Kind
         run: |
           curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
@@ -90,6 +115,7 @@ jobs:
 
   test-upgrade-from-N-1:
     name: Upgrade from Theia version N-1
+    needs: build-clickhouse-monitor-image
     runs-on: [ubuntu-latest]
     steps:
       - name: Free disk space
@@ -101,6 +127,14 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
+      - name: Download ClickHouse monitor images from previous jobs
+        uses: actions/download-artifact@v3
+        with:
+          name: clickhouse-monitor
+      - name: Load Theia image
+        run:  |
+          docker load -i clickhouse-monitor.tar
+          docker tag antrea/theia-clickhouse-monitor:latest projects.registry.vmware.com/antrea/theia-clickhouse-monitor:latest
       - name: Install Kind
         run: |
           curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
@@ -121,14 +155,17 @@ jobs:
           path: log.tar.gz
           retention-days: 30
 
-  # Runs after all other jobs in the workflow and deletes Theia Docker images uploaded as temporary
+  # Runs after all other jobs in the workflow succeed and deletes Theia Docker images uploaded as temporary
   # artifacts. It uses a third-party, MIT-licensed action (geekyeggo/delete-artifact). While Github
   # exposes an API for deleting artifacts, they do not support an official delete-artifact action
   # yet.
   artifact-cleanup:
     name: Delete uploaded images
-    needs: [build-policy-recommendation-image, test-e2e-encap]
-    if: ${{ always() && needs.build-policy-recommendation-image.result == 'success' }}
+    needs:
+    - build-policy-recommendation-image
+    - build-clickhouse-monitor-image
+    - test-e2e-encap
+    - test-upgrade-from-N-1
     runs-on: [ubuntu-latest]
     steps:
     - name: Delete policy-recommendation
@@ -136,3 +173,8 @@ jobs:
       uses: geekyeggo/delete-artifact@v1
       with:
         name: policy-recommendation
+    - name: Delete clickhouse-monitor
+      if: ${{ needs.build-clickhouse-monitor-image.result == 'success' }}
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: clickhouse-monitor

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -326,6 +326,7 @@ function deliver_antrea {
     chmod a+x ~/bin/yq
 
     FA_YAML=${GIT_CHECKOUT_DIR}/build/yamls/flow-aggregator.yml
+    sed -i -e "s|image: projects.registry.vmware.com/antrea/flow-aggregator:latest|image: antrea/flow-aggregator:latest|g" $FA_YAML
     flow_aggregator_conf=$(
         ~/bin/yq e 'select(.metadata.name == "flow-aggregator-configmap*").data."flow-aggregator.conf"' $FA_YAML \
             | ~/bin/yq e  \
@@ -356,17 +357,18 @@ function deliver_antrea {
     docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_TOKEN
 
     docker pull antrea/antrea-ubuntu:latest
-    docker pull projects.registry.vmware.com/antrea/flow-aggregator:latest
+    docker pull antrea/flow-aggregator:latest
     docker pull projects.registry.vmware.com/antrea/theia-spark-operator:v1beta2-1.3.3-3.1.1
     docker pull projects.registry.vmware.com/antrea/theia-zookeeper:3.8.0
 
     docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu:latest
-    docker save -o flow-aggregator.tar projects.registry.vmware.com/antrea/flow-aggregator:latest
+    docker save -o flow-aggregator.tar antrea/flow-aggregator:latest
     docker save -o theia-spark-operator.tar projects.registry.vmware.com/antrea/theia-spark-operator:v1beta2-1.3.3-3.1.1
     docker save -o theia-zookeeper.tar projects.registry.vmware.com/antrea/theia-zookeeper:3.8.0
 
-    (cd $GIT_CHECKOUT_DIR && make policy-recommendation)
+    (cd $GIT_CHECKOUT_DIR && make policy-recommendation && make clickhouse-monitor)
     docker save -o theia-policy-recommendation.tar projects.registry.vmware.com/antrea/theia-policy-recommendation:latest
+    docker save -o theia-clickhouse-monitor.tar projects.registry.vmware.com/antrea/theia-clickhouse-monitor:latest
 
     # not sure the exact image tag, so read from yaml
     # and we assume the image tag is the same for all images in this yaml
@@ -384,12 +386,13 @@ function deliver_antrea {
     do
         ssh-keygen -f "/var/lib/jenkins/.ssh/known_hosts" -R ${IPs[$i]}
         copy_image antrea-ubuntu.tar docker.io/antrea/antrea-ubuntu ${IPs[$i]} latest true
-        copy_image flow-aggregator.tar projects.registry.vmware.com/antrea/flow-aggregator ${IPs[$i]} latest  true
+        copy_image flow-aggregator.tar docker.io/antrea/flow-aggregator ${IPs[$i]} latest  true
         copy_image theia-clickhouse-operator.tar projects.registry.vmware.com/antrea/theia-clickhouse-operator  ${IPs[$i]} $image_tag true
         copy_image theia-metrics-exporter.tar projects.registry.vmware.com/antrea/theia-metrics-exporter  ${IPs[$i]} $image_tag true
         copy_image theia-zookeeper.tar projects.registry.vmware.com/antrea/theia-zookeeper  ${IPs[$i]} 3.8.0 true
         copy_image theia-spark-operator.tar projects.registry.vmware.com/antrea/theia-spark-operator ${IPs[$i]} v1beta2-1.3.3-3.1.1 true
         copy_image theia-policy-recommendation.tar projects.registry.vmware.com/antrea/theia-policy-recommendation ${IPs[$i]} latest true
+        copy_image theia-clickhouse-monitor.tar projects.registry.vmware.com/antrea/theia-clickhouse-monitor ${IPs[$i]} latest true
     done
 }
 

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -112,7 +112,6 @@ COMMON_IMAGES_LIST=("k8s.gcr.io/e2e-test-images/agnhost:2.29" \
                     "projects.registry.vmware.com/antrea/theia-clickhouse-operator:0.18.2" \
                     "projects.registry.vmware.com/antrea/theia-metrics-exporter:0.18.2" \
                     "projects.registry.vmware.com/antrea/theia-clickhouse-server:21.11" \
-                    "projects.registry.vmware.com/antrea/theia-clickhouse-monitor:latest" \
                     "projects.registry.vmware.com/antrea/theia-zookeeper:3.8.0" \
                     "projects.registry.vmware.com/antrea/theia-grafana:8.3.3" \
                     "projects.registry.vmware.com/antrea/theia-spark-operator:v1beta2-1.3.3-3.1.1")
@@ -124,7 +123,8 @@ for image in "${COMMON_IMAGES_LIST[@]}"; do
     done
 done
 
-COMMON_IMAGES_LIST+=("projects.registry.vmware.com/antrea/theia-policy-recommendation:latest")
+COMMON_IMAGES_LIST+=("projects.registry.vmware.com/antrea/theia-policy-recommendation:latest"\
+                     "projects.registry.vmware.com/antrea/theia-clickhouse-monitor:latest")
 printf -v COMMON_IMAGES "%s " "${COMMON_IMAGES_LIST[@]}"
 
 function setup_cluster {

--- a/ci/kind/test-upgrade-theia.sh
+++ b/ci/kind/test-upgrade-theia.sh
@@ -154,8 +154,7 @@ DOCKER_IMAGES=("k8s.gcr.io/e2e-test-images/agnhost:2.29" \
                 "projects.registry.vmware.com/antrea/theia-grafana:8.3.3" \
                 "projects.registry.vmware.com/antrea/antrea-ubuntu:$ANTREA_FROM_TAG" \
                 "projects.registry.vmware.com/antrea/theia-clickhouse-monitor:$THEIA_FROM_TAG" \
-                "antrea/antrea-ubuntu:latest" \
-                "projects.registry.vmware.com/antrea/theia-clickhouse-monitor:latest")
+                "antrea/antrea-ubuntu:latest")
 
 for img in "${DOCKER_IMAGES[@]}"; do
     echo "Pulling $img"
@@ -164,6 +163,8 @@ for img in "${DOCKER_IMAGES[@]}"; do
         sleep 1
     done
 done
+
+DOCKER_IMAGES+=("projects.registry.vmware.com/antrea/theia-clickhouse-monitor:latest")
 
 echo "Creating Kind cluster"
 IMAGES="${DOCKER_IMAGES[@]}"

--- a/plugins/clickhouse-monitor/main.go
+++ b/plugins/clickhouse-monitor/main.go
@@ -270,7 +270,7 @@ func monitorMemory(connect *sql.DB) {
 		tables := append([]string{tableName}, mvNames...)
 		for _, table := range tables {
 			// Delete all records inserted earlier than an upper boundary of timeInserted
-			query := fmt.Sprintf("ALTER TABLE %s DELETE WHERE timeInserted < toDateTime('$1')", table)
+			query := fmt.Sprintf("ALTER TABLE %s DELETE WHERE timeInserted < toDateTime(?)", table)
 			// #nosec G201: table and view names were sanitized earlier
 			if _, err := connect.Exec(query, timeBoundary.Format(timeFormat)); err != nil {
 				klog.ErrorS(err, "Failed to delete records from ClickHouse", "table", table)
@@ -289,7 +289,7 @@ func getTimeBoundary(connect *sql.DB) (time.Time, error) {
 	if err != nil {
 		return timeBoundary, err
 	}
-	query := fmt.Sprintf("SELECT timeInserted FROM %s LIMIT 1 OFFSET $1", tableName)
+	query := fmt.Sprintf("SELECT timeInserted FROM %s LIMIT 1 OFFSET (?)", tableName)
 	if err := wait.PollImmediate(queryRetryInterval, queryTimeout, func() (bool, error) {
 		// #nosec G201: table name was sanitized earlier
 		if err := connect.QueryRow(query, deleteRowNum-1).Scan(&timeBoundary); err != nil {

--- a/plugins/clickhouse-monitor/main_test.go
+++ b/plugins/clickhouse-monitor/main_test.go
@@ -62,9 +62,9 @@ func testMonitorMemoryWithDeletion(t *testing.T, db *sql.DB, mock sqlmock.Sqlmoc
 	mock.ExpectQuery("SELECT free_space, total_space FROM system.disks").WillReturnRows(diskRow)
 	mock.ExpectQuery("SELECT SUM(bytes) FROM system.parts").WillReturnRows(partsRow)
 	mock.ExpectQuery("SELECT COUNT() FROM flows").WillReturnRows(countRow)
-	mock.ExpectQuery("SELECT timeInserted FROM flows LIMIT 1 OFFSET $1").WithArgs(4).WillReturnRows(timeRow)
+	mock.ExpectQuery("SELECT timeInserted FROM flows LIMIT 1 OFFSET (?)").WithArgs(4).WillReturnRows(timeRow)
 	for _, table := range []string{"flows", "flows_pod_view", "flows_node_view", "flows_policy_view"} {
-		query := fmt.Sprintf("ALTER TABLE %s DELETE WHERE timeInserted < toDateTime('$1')", table)
+		query := fmt.Sprintf("ALTER TABLE %s DELETE WHERE timeInserted < toDateTime(?)", table)
 		mock.ExpectExec(query).WithArgs(baseTime.Add(5 * time.Second).Format(timeFormat)).WillReturnResult(sqlmock.NewResult(0, 5))
 	}
 

--- a/test/e2e/flowvisibility_test.go
+++ b/test/e2e/flowvisibility_test.go
@@ -660,9 +660,9 @@ func checkClickHouseMonitorLogs(t *testing.T, data *TestData, deleted bool, numR
 		assert.Contains(t, logString, "ALTER TABLE default.flows_node_view_local DELETE WHERE timeInserted < toDateTime", "Monitor should delete records from View flows_node_view")
 		assert.Contains(t, logString, "ALTER TABLE default.flows_policy_view_local DELETE WHERE timeInserted < toDateTime", "Monitor should delete records from View flows_policy_view")
 		assert.Contains(t, logString, "Skip rounds after a successful deletion", "Monitor should skip rounds after a successful deletion")
-		require.Contains(t, logString, "SELECT timeInserted FROM default.flows_local LIMIT 1 OFFSET ", "Monitor should log the deletion SQL command")
-		deletedRecordLog := strings.Split(logString, "SELECT timeInserted FROM default.flows_local LIMIT 1 OFFSET ")[1]
-		deletedRecordLog = strings.Split(deletedRecordLog, "\n")[0]
+		require.Contains(t, logString, "[send query] SELECT timeInserted FROM default.flows_local LIMIT 1 OFFSET (", "Monitor should log the deletion SQL command")
+		deletedRecordLog := strings.Split(logString, "[send query] SELECT timeInserted FROM default.flows_local LIMIT 1 OFFSET (")[1]
+		deletedRecordLog = strings.Split(deletedRecordLog, ")\n")[0]
 		numDeletedRecord, err := strconv.ParseInt(deletedRecordLog, 10, 64)
 		require.NoErrorf(t, err, "Failed when parsing the number of deleted records %v", err)
 


### PR DESCRIPTION
`clickhouse-go/v1` does not support `$` as the placeholder and
leads to errors in e2e tests.

As we pull ClickHouse monitor image from Harbor to run e2e tests,
this bug is not detected when it is introduced. This PR also updates
the workflow to build the ClickHouse monitor image for kind/jenkins
e2e tests.

Signed-off-by: Yanjun Zhou <zhouya@vmware.com>