### PR TITLE
Add RBAC auth and CA controller to Theia manager

### DIFF
--- a/build/charts/theia/README.md
+++ b/build/charts/theia/README.md
@@ -66,6 +66,7 @@ Kubernetes: `>= 1.16.0-0`
 | sparkOperator.image | object | `{"pullPolicy":"IfNotPresent","repository":"projects.registry.vmware.com/antrea/theia-spark-operator","tag":"v1beta2-1.3.3-3.1.1"}` | Container image used by Spark Operator. |
 | sparkOperator.name | string | `"policy-recommendation"` | Name of Spark Operator. |
 | theiaManager.apiServer.apiPort | int | `11347` | The port for the Theia Manager APIServer to serve on. |
+| theiaManager.apiServer.selfSignedCert | bool | `true` | Indicates whether to use auto-generated self-signed TLS certificates. If false, a Secret named "theia-manager-tls" must be provided with the following keys: ca.crt, tls.crt, tls.key. |
 | theiaManager.apiServer.tlsCipherSuites | string | `""` | Comma-separated list of cipher suites that will be used by the Theia Manager APIservers. If empty, the default Go Cipher Suites will be used. |
 | theiaManager.apiServer.tlsMinVersion | string | `""` | TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. |
 | theiaManager.enable | bool | `false` | Determine whether to install Theia Manager. |

--- a/build/charts/theia/conf/theia-manager.conf
+++ b/build/charts/theia/conf/theia-manager.conf
@@ -3,6 +3,13 @@ apiServer:
   # The port for the theia-manager APIServer to serve on.
   apiPort: {{ .Values.theiaManager.apiServer.apiPort }}
 
+  # Indicates whether to use auto-generated self-signed TLS certificate.
+  # If false, a Secret named "theia-manager-tls" must be provided with the following keys:
+  #   ca.crt: <CA certificate>
+  #   tls.crt: <TLS certificate>
+  #   tls.key: <TLS private key>
+  selfSignedCert: {{ .Values.theiaManager.apiServer.selfSignedCert }}
+
   # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
   # https://golang.org/pkg/crypto/tls/#pkg-constants
   # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always

--- a/build/charts/theia/templates/theia-cli/clusterrole.yaml
+++ b/build/charts/theia/templates/theia-cli/clusterrole.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: theia-cli
+  labels:
+    app: theia-cli
+rules:
+  - apiGroups:
+      - intelligence.theia.antrea.io
+    resources:
+      - networkpolicyrecommendations
+    verbs:
+      - get
+      - list

--- a/build/charts/theia/templates/theia-cli/clusterrole.yaml
+++ b/build/charts/theia/templates/theia-cli/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.theiaManager.enable }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -12,3 +13,4 @@ rules:
     verbs:
       - get
       - list
+{{- end }}

--- a/build/charts/theia/templates/theia-cli/clusterrolebinding.yaml
+++ b/build/charts/theia/templates/theia-cli/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.theiaManager.enable }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -12,3 +13,4 @@ subjects:
   - kind: ServiceAccount
     name: theia-cli
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/build/charts/theia/templates/theia-cli/clusterrolebinding.yaml
+++ b/build/charts/theia/templates/theia-cli/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: theia-cli
+  name: theia-cli
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: theia-cli
+subjects:
+  - kind: ServiceAccount
+    name: theia-cli
+    namespace: {{ .Release.Namespace }}

--- a/build/charts/theia/templates/theia-cli/secret.yaml
+++ b/build/charts/theia/templates/theia-cli/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.theiaManager.enable }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +7,4 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: theia-cli
 type: kubernetes.io/service-account-token
+{{- end }}

--- a/build/charts/theia/templates/theia-cli/secret.yaml
+++ b/build/charts/theia/templates/theia-cli/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: theia-cli-account-token
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: theia-cli
+type: kubernetes.io/service-account-token

--- a/build/charts/theia/templates/theia-cli/serviceaccount.yaml
+++ b/build/charts/theia/templates/theia-cli/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: theia-cli
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: theia-cli

--- a/build/charts/theia/templates/theia-cli/serviceaccount.yaml
+++ b/build/charts/theia/templates/theia-cli/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.theiaManager.enable }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,3 +6,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: theia-cli
+{{- end }}

--- a/build/charts/theia/templates/theia-manager/clusterrole.yaml
+++ b/build/charts/theia/templates/theia-manager/clusterrole.yaml
@@ -18,6 +18,21 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - theia-ca
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
   # This is the content of built-in role kube-system/extension-apiserver-authentication-reader.
   # But it doesn't have list/watch permission before K8s v1.17.0 so the extension apiserver (antrea-agent) will
   # have permission issue after bumping up apiserver library to a version that supports dynamic authentication.

--- a/build/charts/theia/templates/theia-manager/clusterrole.yaml
+++ b/build/charts/theia/templates/theia-manager/clusterrole.yaml
@@ -6,6 +6,18 @@ metadata:
     app: theia-manager
   name: theia-manager-role
 rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
   # This is the content of built-in role kube-system/extension-apiserver-authentication-reader.
   # But it doesn't have list/watch permission before K8s v1.17.0 so the extension apiserver (antrea-agent) will
   # have permission issue after bumping up apiserver library to a version that supports dynamic authentication.

--- a/build/charts/theia/templates/theia-manager/deployment.yaml
+++ b/build/charts/theia/templates/theia-manager/deployment.yaml
@@ -47,6 +47,8 @@ spec:
             - mountPath: /etc/theia-manager
               name: theia-manager-config
               readOnly: true
+            - mountPath: /var/run/theia/theia-manager-tls
+              name: theia-manager-tls
             - mountPath: /var/log/antrea/theia-manager
               name: host-var-log-antrea-theia-manager
       nodeSelector:
@@ -57,6 +59,12 @@ spec:
         - name: theia-manager-config
           configMap:
             name: theia-manager-configmap
+        # Make it optional as we only read it when selfSignedCert=false.
+        - name: theia-manager-tls
+          secret:
+            secretName: theia-manager-tls
+            defaultMode: 0400
+            optional: true
         - name: host-var-log-antrea-theia-manager
           hostPath:
             path: /var/log/antrea/theia-manager

--- a/build/charts/theia/values.yaml
+++ b/build/charts/theia/values.yaml
@@ -224,6 +224,10 @@ theiaManager:
   apiServer:
     # -- The port for the Theia Manager APIServer to serve on.
     apiPort: 11347
+    # -- Indicates whether to use auto-generated self-signed TLS certificates. If
+    # false, a Secret named "theia-manager-tls" must be provided with the
+    # following keys: ca.crt, tls.crt, tls.key.
+    selfSignedCert: true
     # -- Comma-separated list of cipher suites that will be used by the Theia Manager
     # APIservers. If empty, the default Go Cipher Suites will be used.
     tlsCipherSuites: ""

--- a/build/yamls/flow-visibility.yml
+++ b/build/yamls/flow-visibility.yml
@@ -18,6 +18,14 @@ metadata:
   name: grafana
   namespace: flow-visibility
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: theia-cli
+  name: theia-cli
+  namespace: flow-visibility
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -36,6 +44,21 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: theia-cli
+  name: theia-cli
+rules:
+- apiGroups:
+  - intelligence.theia.antrea.io
+  resources:
+  - networkpolicyrecommendations
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
@@ -49,6 +72,21 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: grafana
+  namespace: flow-visibility
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: theia-cli
+  name: theia-cli
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: theia-cli
+subjects:
+- kind: ServiceAccount
+  name: theia-cli
   namespace: flow-visibility
 ---
 apiVersion: v1
@@ -5858,6 +5896,15 @@ stringData:
   admin-password: admin
   admin-username: admin
 type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: theia-cli
+  name: theia-cli-account-token
+  namespace: flow-visibility
+type: kubernetes.io/service-account-token
 ---
 apiVersion: v1
 kind: Service

--- a/build/yamls/flow-visibility.yml
+++ b/build/yamls/flow-visibility.yml
@@ -18,14 +18,6 @@ metadata:
   name: grafana
   namespace: flow-visibility
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app: theia-cli
-  name: theia-cli
-  namespace: flow-visibility
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -44,21 +36,6 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app: theia-cli
-  name: theia-cli
-rules:
-- apiGroups:
-  - intelligence.theia.antrea.io
-  resources:
-  - networkpolicyrecommendations
-  verbs:
-  - get
-  - list
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
@@ -72,21 +49,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: grafana
-  namespace: flow-visibility
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app: theia-cli
-  name: theia-cli
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: theia-cli
-subjects:
-- kind: ServiceAccount
-  name: theia-cli
   namespace: flow-visibility
 ---
 apiVersion: v1
@@ -5896,15 +5858,6 @@ stringData:
   admin-password: admin
   admin-username: admin
 type: Opaque
----
-apiVersion: v1
-kind: Secret
-metadata:
-  annotations:
-    kubernetes.io/service-account.name: theia-cli
-  name: theia-cli-account-token
-  namespace: flow-visibility
-type: kubernetes.io/service-account-token
 ---
 apiVersion: v1
 kind: Service

--- a/cmd/theia-manager/options.go
+++ b/cmd/theia-manager/options.go
@@ -81,4 +81,11 @@ func (o *Options) setDefaults() {
 	if o.config.APIServer.APIPort == 0 {
 		o.config.APIServer.APIPort = apis.TheiaManagerAPIPort
 	}
+	if o.config.APIServer.SelfSignedCert == nil {
+		o.config.APIServer.SelfSignedCert = ptrBool(true)
+	}
+}
+
+func ptrBool(value bool) *bool {
+	return &value
 }

--- a/pkg/apiserver/certificate/cacert_controller.go
+++ b/pkg/apiserver/certificate/cacert_controller.go
@@ -1,0 +1,205 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server/dynamiccertificates"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"antrea.io/theia/pkg/util/env"
+)
+
+const (
+	CAConfigMapKey = "ca.crt"
+)
+
+// CACertController is responsible for taking the CA certificate from the
+// caContentProvider and publishing it to the ConfigMap and the APIServices.
+type CACertController struct {
+	mutex sync.RWMutex
+
+	// caContentProvider provides the very latest content of the ca bundle.
+	caContentProvider dynamiccertificates.CAContentProvider
+	// queue only ever has one item, but it has nice error handling backoff/retry semantics
+	queue workqueue.RateLimitingInterface
+
+	client   kubernetes.Interface
+	caConfig *CAConfig
+}
+
+var _ dynamiccertificates.Listener = &CACertController{}
+
+func GetCAConfigMapNamespace() string {
+	return env.GetTheiaNamespace()
+}
+
+func newCACertController(caContentProvider dynamiccertificates.CAContentProvider,
+	client kubernetes.Interface,
+	caConfig *CAConfig,
+) *CACertController {
+	c := &CACertController{
+		caContentProvider: caContentProvider,
+		queue:             workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "CACertController"),
+		client:            client,
+		caConfig:          caConfig,
+	}
+	if notifier, ok := caContentProvider.(dynamiccertificates.Notifier); ok {
+		notifier.AddListener(c)
+	}
+	return c
+}
+
+func (c *CACertController) UpdateCertificate(ctx context.Context) error {
+	if controller, ok := c.caContentProvider.(dynamiccertificates.ControllerRunner); ok {
+		if err := controller.RunOnce(ctx); err != nil {
+			klog.Warningf("Updating of CA content failed: %v", err)
+			c.Enqueue()
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getCertificate exposes the certificate for testing.
+func (c *CACertController) getCertificate() []byte {
+	return c.caContentProvider.CurrentCABundleContent()
+}
+
+// Enqueue will be called after CACertController is registered as a listener of CA cert change.
+func (c *CACertController) Enqueue() {
+	// The key can be anything as we only have single item.
+	c.queue.Add("key")
+}
+
+func (c *CACertController) syncCACert() error {
+	caCert := c.caContentProvider.CurrentCABundleContent()
+
+	if err := c.syncConfigMap(caCert); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// syncConfigMap updates the ConfigMap that holds the CA bundle, which will be read by API clients.
+func (c *CACertController) syncConfigMap(caCert []byte) error {
+	klog.InfoS("Syncing CA certificate with ConfigMap")
+	// Use the Theia manager Pod Namespace for the CA cert ConfigMap.
+	caConfigMapNamespace := GetCAConfigMapNamespace()
+	caConfigMap, err := c.client.CoreV1().ConfigMaps(caConfigMapNamespace).Get(context.TODO(), c.caConfig.CAConfigMapName, metav1.GetOptions{})
+	exists := true
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("error getting ConfigMap %s: %v", c.caConfig.CAConfigMapName, err)
+		}
+		exists = false
+		caConfigMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      c.caConfig.CAConfigMapName,
+				Namespace: caConfigMapNamespace,
+				Labels: map[string]string{
+					"app": "theia",
+				},
+			},
+		}
+	}
+	if caConfigMap.Data != nil && caConfigMap.Data[CAConfigMapKey] == string(caCert) {
+		return nil
+	}
+	caConfigMap.Data = map[string]string{
+		CAConfigMapKey: string(caCert),
+	}
+	if exists {
+		if _, err := c.client.CoreV1().ConfigMaps(caConfigMapNamespace).Update(context.TODO(), caConfigMap, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("error updating ConfigMap %s: %v", c.caConfig.CAConfigMapName, err)
+		}
+	} else {
+		if _, err := c.client.CoreV1().ConfigMaps(caConfigMapNamespace).Create(context.TODO(), caConfigMap, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("error creating ConfigMap %s: %v", c.caConfig.CAConfigMapName, err)
+		}
+	}
+	return nil
+}
+
+// RunOnce runs a single sync step to ensure that we have a valid starting configuration.
+func (c *CACertController) RunOnce(ctx context.Context) error {
+	if controller, ok := c.caContentProvider.(dynamiccertificates.ControllerRunner); ok {
+		if err := controller.RunOnce(ctx); err != nil {
+			klog.Warningf("Initial population of CA content failed: %v", err)
+			c.Enqueue()
+			return err
+		}
+	}
+	if err := c.syncCACert(); err != nil {
+		klog.Warningf("Initial sync of CA content failed: %v", err)
+		c.Enqueue()
+		return err
+	}
+	return nil
+}
+
+// Run starts the CACertController and blocks until the context is canceled.
+func (c *CACertController) Run(ctx context.Context, workers int) {
+	defer c.queue.ShutDown()
+
+	klog.InfoS("Starting CACertController")
+	defer klog.InfoS("Shutting down CACertController")
+
+	if controller, ok := c.caContentProvider.(dynamiccertificates.ControllerRunner); ok {
+		// doesn't matter what workers say, only start one.
+		go controller.Run(ctx, 1)
+	}
+
+	// doesn't matter what workers say, only start one.
+	go wait.Until(c.runWorker, time.Second, ctx.Done())
+
+	<-ctx.Done()
+}
+
+func (c *CACertController) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *CACertController) processNextWorkItem() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.syncCACert()
+	if err == nil {
+		c.queue.Forget(key)
+		return true
+	}
+
+	klog.ErrorS(err, "Error when syncing CA cert, requeuing")
+	c.queue.AddRateLimited(key)
+
+	return true
+}

--- a/pkg/apiserver/certificate/certificate.go
+++ b/pkg/apiserver/certificate/certificate.go
@@ -1,0 +1,188 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server/dynamiccertificates"
+	"k8s.io/apiserver/pkg/server/options"
+	"k8s.io/client-go/kubernetes"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+	"k8s.io/klog/v2"
+
+	"antrea.io/theia/pkg/util/env"
+)
+
+const (
+	// The names of the files that should contain the CA certificate and the TLS key pair.
+	CACertFile  = "ca.crt"
+	TLSCertFile = "tls.crt"
+	TLSKeyFile  = "tls.key"
+)
+
+// GetTheiaServerNames returns the DNS names that the TLS certificate will be signed with.
+func GetTheiaServerNames(serviceName string) []string {
+	namespace := env.GetTheiaNamespace()
+	theiaServerName := serviceName + "." + namespace + ".svc"
+	// TODO: Add the whole FQDN "theia-manager.<Namespace>.svc.<Cluster Domain>" as an
+	// alternate DNS name when other clients need to access it directly with that name.
+	return []string{theiaServerName}
+}
+
+func ApplyServerCert(selfSignedCert bool,
+	client kubernetes.Interface,
+	secureServing *options.SecureServingOptionsWithLoopback,
+	caConfig *CAConfig) (*CACertController, error) {
+	var err error
+	var caContentProvider dynamiccertificates.CAContentProvider
+	if selfSignedCert {
+		caContentProvider, err = generateSelfSignedCertificate(secureServing, caConfig)
+		if err != nil {
+			return nil, fmt.Errorf("error creating self-signed CA certificate: %v", err)
+		}
+	} else {
+		caCertPath := path.Join(caConfig.CertDir, CACertFile)
+		tlsCertPath := path.Join(caConfig.CertDir, TLSCertFile)
+		tlsKeyPath := path.Join(caConfig.CertDir, TLSKeyFile)
+		// The secret may be created after the Pod is created, for example, when cert-manager is used the secret
+		// is created asynchronously. It waits for a while before it's considered to be failed.
+		if err = wait.PollImmediate(2*time.Second, caConfig.CertReadyTimeout, func() (bool, error) {
+			for _, path := range []string{caCertPath, tlsCertPath, tlsKeyPath} {
+				f, err := os.Open(path)
+				if err != nil {
+					klog.Warningf("Couldn't read %s when applying server certificate, retrying", path)
+					return false, nil
+				}
+				f.Close()
+			}
+			return true, nil
+		}); err != nil {
+			return nil, fmt.Errorf("error reading TLS certificate and/or key. Please make sure the TLS CA (%s), cert (%s), and key (%s) files are present in \"%s\", when selfSignedCert is set to false", CACertFile, TLSCertFile, TLSKeyFile, caConfig.CertDir)
+		}
+		// Since 1.17.0 (https://github.com/kubernetes/kubernetes/commit/3f5fbfbfac281f40c11de2f57d58cc332affc37b),
+		// apiserver reloads certificate cert and key file from disk every minute, allowing serving tls config to be updated.
+		secureServing.ServerCert.CertKey.CertFile = tlsCertPath
+		secureServing.ServerCert.CertKey.KeyFile = tlsKeyPath
+
+		caContentProvider, err = dynamiccertificates.NewDynamicCAContentFromFile("user-provided CA cert", caCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("error reading user-provided CA certificate: %v", err)
+		}
+	}
+
+	caCertController := newCACertController(caContentProvider, client, caConfig)
+
+	if selfSignedCert {
+		go rotateSelfSignedCertificates(caCertController, secureServing, caConfig.MaxRotateDuration)
+	}
+
+	return caCertController, nil
+}
+
+// generateSelfSignedCertificate generates a new self signed certificate.
+func generateSelfSignedCertificate(secureServing *options.SecureServingOptionsWithLoopback, caConfig *CAConfig) (dynamiccertificates.CAContentProvider, error) {
+	var err error
+	var caContentProvider dynamiccertificates.CAContentProvider
+
+	// Set the PairName and CertDirectory to generate the certificate files.
+	secureServing.ServerCert.CertDirectory = caConfig.SelfSignedCertDir
+	secureServing.ServerCert.PairName = caConfig.PairName
+
+	if err := secureServing.MaybeDefaultWithSelfSignedCerts(caConfig.ServiceName, GetTheiaServerNames(caConfig.ServiceName), []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback}); err != nil {
+		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
+	}
+
+	caContentProvider, err = dynamiccertificates.NewDynamicCAContentFromFile("self-signed cert", secureServing.ServerCert.CertKey.CertFile)
+	if err != nil {
+		return nil, fmt.Errorf("error reading self-signed CA certificate: %v", err)
+	}
+
+	return caContentProvider, nil
+}
+
+// Used to determine which is sooner, the provided maxRotateDuration or the expiration date
+// of the cert. Used to allow for unit testing with a far shorter rotation period.
+// Also can be used to pass a user provided rotation window.
+func nextRotationDuration(secureServing *options.SecureServingOptionsWithLoopback,
+	maxRotateDuration time.Duration) (time.Duration, error) {
+
+	x509Cert, err := certutil.CertsFromFile(secureServing.ServerCert.CertKey.CertFile)
+	if err != nil {
+		return time.Duration(0), fmt.Errorf("error parsing generated certificate: %v", err)
+	}
+
+	// Attempt to rotate the certificate at the half-way point of expiration.
+	// Unless the halfway point is longer than maxRotateDuration
+	duration := x509Cert[0].NotAfter.Sub(time.Now()) / 2
+
+	waitDuration := duration
+	if maxRotateDuration < waitDuration {
+		waitDuration = maxRotateDuration
+	}
+
+	return waitDuration, nil
+}
+
+// rotateSelfSignedCertificates calculates the rotation duration for the current certificate.
+// Then once the duration is complete, generates a new self-signed certificate and repeats the process.
+func rotateSelfSignedCertificates(c *CACertController, secureServing *options.SecureServingOptionsWithLoopback,
+	maxRotateDuration time.Duration) {
+	for {
+		rotationDuration, err := nextRotationDuration(secureServing, maxRotateDuration)
+		if err != nil {
+			klog.ErrorS(err, "Error when reading expiration date of cert")
+			return
+		}
+
+		klog.InfoS("Certificate will be rotated at", "time", time.Now().Add(rotationDuration))
+
+		time.Sleep(rotationDuration)
+
+		klog.InfoS("Rotating self signed certificate")
+
+		err = generateNewServingCertificate(secureServing, c.caConfig)
+		if err != nil {
+			klog.ErrorS(err, "Error when generating new cert")
+			return
+		}
+		c.UpdateCertificate(context.TODO())
+	}
+}
+
+func generateNewServingCertificate(secureServing *options.SecureServingOptionsWithLoopback, caConfig *CAConfig) error {
+	cert, key, err := certutil.GenerateSelfSignedCertKeyWithFixtures(caConfig.ServiceName, []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback}, GetTheiaServerNames(caConfig.ServiceName), secureServing.ServerCert.FixtureDirectory)
+	if err != nil {
+		return fmt.Errorf("unable to generate self signed cert: %v", err)
+	}
+
+	if err := certutil.WriteCert(secureServing.ServerCert.CertKey.CertFile, cert); err != nil {
+		return err
+	}
+	if err := keyutil.WriteKey(secureServing.ServerCert.CertKey.KeyFile, key); err != nil {
+		return err
+	}
+	klog.InfoS("Generated self-signed certificate", "cert", secureServing.ServerCert.CertKey.CertFile,
+		"key", secureServing.ServerCert.CertKey.KeyFile)
+
+	return nil
+}

--- a/pkg/apiserver/certificate/certificate_test.go
+++ b/pkg/apiserver/certificate/certificate_test.go
@@ -1,0 +1,222 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"bytes"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/wait"
+	genericoptions "k8s.io/apiserver/pkg/server/options"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+)
+
+const (
+	fakeTLSCert = `-----BEGIN CERTIFICATE-----
+MIICBDCCAW2gAwIBAgIJAPgVBh+4xbGoMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV
+BAMMEHdlYmhvb2tfdGVzdHNfY2EwIBcNMTcwNzI4MjMxNTI4WhgPMjI5MTA1MTMy
+MzE1MjhaMB8xHTAbBgNVBAMMFHdlYmhvb2tfdGVzdHNfY2xpZW50MIGfMA0GCSqG
+SIb3DQEBAQUAA4GNADCBiQKBgQDkGXXSm6Yun5o3Jlmx45rItcQ2pmnoDk4eZfl0
+rmPa674s2pfYo3KywkXQ1Fp3BC8GUgzPLSfJ8xXya9Lg1Wo8sHrDln0iRg5HXxGu
+uFNhRBvj2S0sIff0ZG/IatB9I6WXVOUYuQj6+A0CdULNj1vBqH9+7uWbLZ6lrD4b
+a44x/wIDAQABo0owSDAJBgNVHRMEAjAAMAsGA1UdDwQEAwIF4DAdBgNVHSUEFjAU
+BggrBgEFBQcDAgYIKwYBBQUHAwEwDwYDVR0RBAgwBocEfwAAATANBgkqhkiG9w0B
+AQsFAAOBgQCpN27uh/LjUVCaBK7Noko25iih/JSSoWzlvc8CaipvSPofNWyGx3Vu
+OdcSwNGYX/pp4ZoAzFij/Y5u0vKTVLkWXATeTMVmlPvhmpYjj9gPkCSY6j/SiKlY
+kGy0xr+0M5UQkMBcfIh9oAp9um1fZHVWAJAGP/ikZgkcUey0LmBn8w==
+-----END CERTIFICATE-----`
+	fakeTLSKey = `-----BEGIN RSA PRIVATE KEY-----
+MIICWwIBAAKBgQDkGXXSm6Yun5o3Jlmx45rItcQ2pmnoDk4eZfl0rmPa674s2pfY
+o3KywkXQ1Fp3BC8GUgzPLSfJ8xXya9Lg1Wo8sHrDln0iRg5HXxGuuFNhRBvj2S0s
+Iff0ZG/IatB9I6WXVOUYuQj6+A0CdULNj1vBqH9+7uWbLZ6lrD4ba44x/wIDAQAB
+AoGAZbWwowvCq1GBq4vPPRI3h739Uz0bRl1ymf1woYXNguXRtCB4yyH+2BTmmrrF
+6AIWkePuUEdbUaKyK5nGu3iOWM+/i6NP3kopQANtbAYJ2ray3kwvFlhqyn1bxX4n
+gl/Cbdw1If4zrDrB66y8mYDsjzK7n/gFaDNcY4GArjvOXKkCQQD9Lgv+WD73y4RP
+yS+cRarlEeLLWVsX/pg2oEBLM50jsdUnrLSW071MjBgP37oOXzqynF9SoDbP2Y5C
+x+aGux9LAkEA5qPlQPv0cv8Wc3qTI+LixZ/86PPHKWnOnwaHm3b9vQjZAkuVQg3n
+Wgg9YDmPM87t3UFH7ZbDihUreUxwr9ZjnQJAZ9Z95shMsxbOYmbSVxafu6m1Sc+R
+M+sghK7/D5jQpzYlhUspGf8n0YBX0hLhXUmjamQGGH5LXL4Owcb4/mM6twJAEVio
+SF/qva9jv+GrKVrKFXT374lOJFY53Qn/rvifEtWUhLCslCA5kzLlctRBafMZPrfH
+Mh5RrJP1BhVysDbenQJASGcc+DiF7rB6K++ZGyC11E2AP29DcZ0pgPESSV7npOGg
++NqPRZNVCSZOiVmNuejZqmwKhZNGZnBFx1Y+ChAAgw==
+-----END RSA PRIVATE KEY-----`
+	fakeCACert = `-----BEGIN CERTIFICATE-----
+MIICBDCCAW2gAwIBAgIJAPgVBh+4xbGoMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV
+BAMMEHdlYmhvb2tfdGVzdHNfY2EwIBcNMTcwNzI4MjMxNTI4WhgPMjI5MTA1MTMy
+MzE1MjhaMB8xHTAbBgNVBAMMFHdlYmhvb2tfdGVzdHNfY2xpZW50MIGfMA0GCSqG
+SIb3DQEBAQUAA4GNADCBiQKBgQDkGXXSm6Yun5o3Jlmx45rItcQ2pmnoDk4eZfl0
+rmPa674s2pfYo3KywkXQ1Fp3BC8GUgzPLSfJ8xXya9Lg1Wo8sHrDln0iRg5HXxGu
+uFNhRBvj2S0sIff0ZG/IatB9I6WXVOUYuQj6+A0CdULNj1vBqH9+7uWbLZ6lrD4b
+a44x/wIDAQABo0owSDAJBgNVHRMEAjAAMAsGA1UdDwQEAwIF4DAdBgNVHSUEFjAU
+BggrBgEFBQcDAgYIKwYBBQUHAwEwDwYDVR0RBAgwBocEfwAAATANBgkqhkiG9w0B
+AQsFAAOBgQCpN27uh/LjUVCaBK7Noko25iih/JSSoWzlvc8CaipvSPofNWyGx3Vu
+OdcSwNGYX/pp4ZoAzFij/Y5u0vKTVLkWXATeTMVmlPvhmpYjj9gPkCSY6j/SiKlY
+kGy0xr+0M5UQkMBcfIh9oAp9um1fZHVWAJAGP/ikZgkcUey0LmBn8w==
+-----END CERTIFICATE-----`
+)
+
+func TestApplyServerCert(t *testing.T) {
+	tests := []struct {
+		name              string
+		selfSignedCert    bool
+		tlsCert           []byte
+		tlsKey            []byte
+		caCert            []byte
+		wantErr           bool
+		wantCertKey       bool
+		wantGeneratedCert bool
+		wantCACert        []byte
+		testRotate        bool
+	}{
+		{
+			name:              "self-signed",
+			selfSignedCert:    true,
+			tlsCert:           nil,
+			tlsKey:            nil,
+			caCert:            nil,
+			wantErr:           false,
+			wantCertKey:       false,
+			wantGeneratedCert: true,
+			wantCACert:        nil,
+			testRotate:        false,
+		},
+		{
+			name:              "user-provided",
+			selfSignedCert:    false,
+			tlsCert:           []byte(fakeTLSCert),
+			tlsKey:            []byte(fakeTLSKey),
+			caCert:            []byte(fakeCACert),
+			wantErr:           false,
+			wantCertKey:       true,
+			wantGeneratedCert: false,
+			wantCACert:        []byte(fakeCACert),
+			testRotate:        false,
+		},
+		{
+			name:           "user-provided-missing-tls-crt",
+			selfSignedCert: false,
+			tlsCert:        nil,
+			tlsKey:         []byte(fakeTLSKey),
+			caCert:         []byte(fakeCACert),
+			wantErr:        true,
+			testRotate:     false,
+		},
+		{
+			name:           "user-provided-missing-tls-key",
+			selfSignedCert: false,
+			tlsCert:        []byte(fakeTLSCert),
+			tlsKey:         nil,
+			caCert:         []byte(fakeCACert),
+			wantErr:        true,
+			testRotate:     false,
+		},
+		{
+			name:           "user-provided-missing-ca-crt",
+			selfSignedCert: false,
+			tlsCert:        []byte(fakeTLSCert),
+			tlsKey:         []byte(fakeTLSKey),
+			caCert:         nil,
+			wantErr:        true,
+			testRotate:     false,
+		},
+		{
+			name:              "self-signed-rotate",
+			selfSignedCert:    true,
+			tlsCert:           nil,
+			tlsKey:            nil,
+			caCert:            nil,
+			wantErr:           false,
+			wantCertKey:       false,
+			wantGeneratedCert: true,
+			wantCACert:        nil,
+			testRotate:        true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caConfig := &CAConfig{
+				ServiceName: TheiaServiceName,
+				PairName:    "theia-manager-api",
+			}
+			var err error
+			caConfig.CertDir, err = os.MkdirTemp("", "theia-tls-test")
+			if err != nil {
+				t.Fatalf("Unable to create temporary directory: %v", err)
+			}
+			defer os.RemoveAll(caConfig.CertDir)
+			caConfig.SelfSignedCertDir, err = os.MkdirTemp("", "theia-self-signed")
+			if err != nil {
+				t.Fatalf("Unable to create temporary directory: %v", err)
+			}
+			defer os.RemoveAll(caConfig.SelfSignedCertDir)
+			caConfig.CertReadyTimeout = 100 * time.Millisecond
+			secureServing := genericoptions.NewSecureServingOptions().WithLoopback()
+			if tt.tlsCert != nil {
+				certutil.WriteCert(path.Join(caConfig.CertDir, TLSCertFile), tt.tlsCert)
+			}
+			if tt.tlsKey != nil {
+				keyutil.WriteKey(path.Join(caConfig.CertDir, TLSKeyFile), tt.tlsKey)
+			}
+			if tt.caCert != nil {
+				certutil.WriteCert(path.Join(caConfig.CertDir, CACertFile), tt.caCert)
+			}
+
+			if tt.testRotate {
+				caConfig.MaxRotateDuration = 2 * time.Second
+			}
+
+			clientset := fakeclientset.NewSimpleClientset()
+			got, err := ApplyServerCert(tt.selfSignedCert, clientset, secureServing, caConfig)
+
+			if err != nil || tt.wantErr {
+				if (err != nil) != tt.wantErr {
+					t.Errorf("ApplyServerCert() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+
+			if tt.selfSignedCert && tt.testRotate {
+				oldCertKeyContent := got.getCertificate()
+				err := wait.Poll(time.Second, 8*time.Second, func() (bool, error) {
+					newCertKeyContent := got.getCertificate()
+					equal := bytes.Equal(oldCertKeyContent, newCertKeyContent)
+					return !equal, nil
+				})
+
+				assert.Nil(t, err, "CA cert not updated")
+			}
+
+			if tt.wantCertKey {
+				assert.Equal(t, genericoptions.CertKey{CertFile: caConfig.CertDir + "/tls.crt", KeyFile: caConfig.CertDir + "/tls.key"}, secureServing.ServerCert.CertKey, "CertKey doesn't match")
+			}
+			if tt.wantGeneratedCert {
+				assert.Equal(t, genericoptions.CertKey{CertFile: caConfig.SelfSignedCertDir + "/theia-manager-api.crt", KeyFile: caConfig.SelfSignedCertDir + "/theia-manager-api.key"}, secureServing.ServerCert.CertKey, "SelfSigned certs not generated")
+			} else {
+				assert.NotEqual(t, genericoptions.CertKey{CertFile: caConfig.SelfSignedCertDir + "/theia-manager-api.crt", KeyFile: caConfig.SelfSignedCertDir + "/theia-manager-api.key"}, secureServing.ServerCert.CertKey, "SelfSigned certs generated erroneously")
+			}
+			if tt.wantCACert != nil {
+				assert.Equal(t, tt.wantCACert, got.caContentProvider.CurrentCABundleContent(), "CA cert doesn't match")
+			} else {
+				assert.NotEmpty(t, got.caContentProvider.CurrentCABundleContent(), "CA cert is empty")
+			}
+		})
+	}
+}

--- a/pkg/apiserver/certificate/config.go
+++ b/pkg/apiserver/certificate/config.go
@@ -1,0 +1,45 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import "time"
+
+const (
+	TheiaCAConfigMapName = "theia-ca"
+	TheiaServiceName     = "theia-manager"
+)
+
+type CAConfig struct {
+	// Name of the ConfigMap that will hold the CA certificate that signs the TLS
+	// certificate of theia manager.
+	CAConfigMapName string
+
+	// CertDir is the directory that the TLS Secret should be mounted to. Declaring it as a variable for testing.
+	CertDir string
+
+	// SelfSignedCertDir is the dir self-signed certificates are created in.
+	SelfSignedCertDir string
+
+	// CertReadyTimeout is the timeout we will wait for the TLS Secret being ready. Declaring it as a variable for testing.
+	CertReadyTimeout time.Duration
+
+	// MaxRotateDuration is the max duration for rotating self-signed certificate generated.
+	// In most cases we will rotate the certificate when we reach half the expiration time of the certificate (see nextRotationDuration).
+	// MaxRotateDuration ensures that if a self-signed certificate has a really long expiration (N years), we still attempt to rotate it
+	// within a reasonable time, in this case one year. maxRotateDuration is also used to force certificate rotation in unit tests.
+	MaxRotateDuration time.Duration
+	ServiceName       string
+	PairName          string
+}

--- a/pkg/config/theiamanager/config.go
+++ b/pkg/config/theiamanager/config.go
@@ -23,6 +23,13 @@ type APIServerConfig struct {
 	// APIPort is the port for the theia-manager APIServer to serve on.
 	// Defaults to 11347.
 	APIPort int `yaml:"apiPort,omitempty"`
+	// Indicates whether to use auto-generated self-signed TLS certificate.
+	// If false, a Secret named "theia-manager-tls" must be provided with the following keys:
+	//   ca.crt: <CA certificate>
+	//   tls.crt: <TLS certificate>
+	//   tls.key: <TLS private key>
+	// Defaults to true.
+	SelfSignedCert *bool `yaml:"selfSignedCert,omitempty"`
 	// Cipher suites to use.
 	TLSCipherSuites string `yaml:"tlsCipherSuites,omitempty"`
 	// TLS min version.

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -1,0 +1,49 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"os"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	podNamespaceEnvKey = "POD_NAMESPACE"
+
+	defaultTheiaNamespace = "flow-visibility"
+)
+
+// GetPodNamespace returns Namespace of the Pod where the code executes.
+func GetPodNamespace() string {
+	podNamespace := os.Getenv(podNamespaceEnvKey)
+	if podNamespace == "" {
+		klog.Warningf("Environment variable %s not found", podNamespaceEnvKey)
+	}
+	return podNamespace
+}
+
+// GetTheiaNamespace tries to determine the Namespace in which Theia is running by looking at the
+// POD_NAMESPACE environment variable. If this environment variable is not set (e.g. because the
+// Theia component is not run as a Pod), "flow-visibility" is returned.
+func GetTheiaNamespace() string {
+	namespace := GetPodNamespace()
+	if namespace == "" {
+		klog.Warningf("Failed to get Pod Namespace from environment. Using \"%s\" as the "+
+			"Theia Service Namespace", defaultTheiaNamespace)
+		namespace = defaultTheiaNamespace
+	}
+	return namespace
+}

--- a/pkg/util/env/env_test.go
+++ b/pkg/util/env/env_test.go
@@ -1,0 +1,65 @@
+// Copyright 2022 Antrea Authors
+
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetPodNamespace(t *testing.T) {
+	testTable := map[string]string{
+		"test-namespace": "test-namespace",
+		"":               "",
+	}
+
+	for k, v := range testTable {
+		comparePodNamespace(k, v, t)
+	}
+}
+
+func comparePodNamespace(k, v string, t *testing.T) {
+	if k != "" {
+		_ = os.Setenv(podNamespaceEnvKey, k)
+		defer os.Unsetenv(podNamespaceEnvKey)
+	}
+	podNamespace := GetPodNamespace()
+	if podNamespace != v {
+		t.Errorf("Failed to retrieve pod namespace, want: %s, get: %s", v, podNamespace)
+	}
+}
+
+func TestGetTheiaNamespace(t *testing.T) {
+	testTable := map[string]string{
+		"test-namespace": "test-namespace",
+		"":               "flow-visibility",
+	}
+
+	for k, v := range testTable {
+		compareTheiaNamespace(k, v, t)
+	}
+}
+
+func compareTheiaNamespace(k, v string, t *testing.T) {
+	if k != "" {
+		_ = os.Setenv(podNamespaceEnvKey, k)
+		defer os.Unsetenv(podNamespaceEnvKey)
+	}
+	podNamespace := GetTheiaNamespace()
+	if podNamespace != v {
+		t.Errorf("Failed to retrieve pod namespace, want: %s, get: %s", v, podNamespace)
+	}
+}


### PR DESCRIPTION
This PR aims to enable Theia manager API server access in a secured and authenticated fashion, which brings in the following changes:
- RBAC delegation to kube-apiserver is added. API authorization of Theia manager API endpoints are now administered based on API groups and resources
- ServiceAccount / ClusterRole / ClusterRoleBinding are added to allow Theia CLI to access API server. `token` from `theia-cli-account-token` should be set as `Authorization: Bearer` in HTTP header when making requests.
- CA cert controller is added to expose CA cert used for API server via configmap `theia-ca`. When adding the `ca.crt` in the configmap to trust chain, HTTPs requests can be made in "secure" fashion.

To test these out, after Theia manager from this branch is deployed and running:
- `TOKEN=$(kubectl get secret theia-cli-account-token -n flow-visibility -o json | jq -Mr '.data.token' | base64 -d)`
- `kubectl get cm theia-ca -n flow-visibility -o jsonpath='{.data.ca\.crt}' > ca-cert.pem`
- From cpVM `curl -vvv --cacert ca-cert.pem https://theia-manager.flow-visibility.svc:11347/apis/intelligence.theia.antrea.io/v1alpha1/networkpolicyrecommendations/pr-test --header "Authorization: Bearer $TOKEN" --resolve theia-manager.flow-visibility.svc:11347:<ClusterIPServiceAddr>`
- From out-of-cluster via port-forwarding `curl -vvv --cacert cert.pem  https://localhost:<LocalForwardPort>/apis/intelligence.theia.antrea.io/v1alpha1/networkpolicyrecommendations/pr-test --header "Authorization: Bearer $TOKEN"`
