### PR TITLE
Fix bugs related to ClickHouse data schema upgrading

### DIFF
--- a/build/charts/theia/provisioning/datasources/create_table.sh
+++ b/build/charts/theia/provisioning/datasources/create_table.sh
@@ -80,9 +80,10 @@ clickhouse client -n -h 127.0.0.1 <<-EOSQL
         clusterUUID String,
         trusted UInt8 DEFAULT 0
     ) engine=ReplicatedMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
-    ORDER BY (timeInserted, flowEndSeconds)
-    TTL timeInserted + INTERVAL {{ .Values.clickhouse.ttl }}
-    SETTINGS merge_with_ttl_timeout = {{ $ttlTimeout }};
+    ORDER BY (timeInserted, flowEndSeconds);
+
+    ALTER TABLE flows_local MODIFY TTL timeInserted + INTERVAL {{ .Values.clickhouse.ttl }};
+    ALTER TABLE flows_local MODIFY SETTING merge_with_ttl_timeout={{ $ttlTimeout }};
 
     --Create a Materialized View to aggregate data for pods
     CREATE MATERIALIZED VIEW IF NOT EXISTS flows_pod_view_local
@@ -103,8 +104,6 @@ clickhouse client -n -h 127.0.0.1 <<-EOSQL
         sourceTransportPort,
         destinationTransportPort,
         clusterUUID)
-    TTL timeInserted + INTERVAL {{ .Values.clickhouse.ttl }}
-    SETTINGS merge_with_ttl_timeout = {{ $ttlTimeout }}
     POPULATE
     AS SELECT
         timeInserted,
@@ -146,6 +145,9 @@ clickhouse client -n -h 127.0.0.1 <<-EOSQL
         destinationTransportPort,
         clusterUUID;
 
+    ALTER TABLE ".inner.flows_pod_view_local" MODIFY TTL timeInserted + INTERVAL {{ .Values.clickhouse.ttl }};
+    ALTER TABLE ".inner.flows_pod_view_local" MODIFY SETTING merge_with_ttl_timeout={{ $ttlTimeout }};
+
     --Create a Materialized View to aggregate data for nodes
     CREATE MATERIALIZED VIEW IF NOT EXISTS flows_node_view_local
     ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
@@ -159,8 +161,6 @@ clickhouse client -n -h 127.0.0.1 <<-EOSQL
         sourcePodNamespace,
         destinationPodNamespace,
         clusterUUID)
-    TTL timeInserted + INTERVAL {{ .Values.clickhouse.ttl }}
-    SETTINGS merge_with_ttl_timeout = {{ $ttlTimeout }}
     POPULATE
     AS SELECT
         timeInserted,
@@ -191,6 +191,9 @@ clickhouse client -n -h 127.0.0.1 <<-EOSQL
         sourcePodNamespace,
         destinationPodNamespace,
         clusterUUID;
+
+    ALTER TABLE ".inner.flows_node_view_local" MODIFY TTL timeInserted + INTERVAL {{ .Values.clickhouse.ttl }};
+    ALTER TABLE ".inner.flows_node_view_local" MODIFY SETTING merge_with_ttl_timeout={{ $ttlTimeout }};
 
     --Create a Materialized View to aggregate data for network policies
     CREATE MATERIALIZED VIEW IF NOT EXISTS flows_policy_view_local
@@ -216,8 +219,6 @@ clickhouse client -n -h 127.0.0.1 <<-EOSQL
         destinationServicePortName,
         destinationIP,
         clusterUUID)
-    TTL timeInserted + INTERVAL {{ .Values.clickhouse.ttl }}
-    SETTINGS merge_with_ttl_timeout = {{ $ttlTimeout }}
     POPULATE
     AS SELECT
         timeInserted,
@@ -270,6 +271,9 @@ clickhouse client -n -h 127.0.0.1 <<-EOSQL
         destinationServicePortName,
         destinationIP,
         clusterUUID;
+
+    ALTER TABLE ".inner.flows_policy_view_local" MODIFY TTL timeInserted + INTERVAL {{ .Values.clickhouse.ttl }};
+    ALTER TABLE ".inner.flows_policy_view_local" MODIFY SETTING merge_with_ttl_timeout={{ $ttlTimeout }};
 
     --Create a table to store the network policy recommendation results
     CREATE TABLE IF NOT EXISTS recommendations_local (

--- a/build/charts/theia/templates/clickhouse/configmap.yaml
+++ b/build/charts/theia/templates/clickhouse/configmap.yaml
@@ -6,4 +6,4 @@ metadata:
 data:
 {{ tpl (.Files.Glob "provisioning/datasources/*.sh").AsConfig . | indent 2 }}
 {{ tpl (.Files.Glob "provisioning/datasources/migrators/downgrade/*").AsConfig . | indent 2 }}
-{{ tpl (.Files.Glob "provisioning/datasources/migrators/*.sql").AsConfig . | indent 2 }}
+{{ (.Files.Glob "provisioning/datasources/migrators/*.sql").AsConfig | indent 2 }}

--- a/build/yamls/flow-visibility.yml
+++ b/build/yamls/flow-visibility.yml
@@ -113,9 +113,7 @@ data:
         reverseThroughputFromDestinationNode UInt64,
         trusted UInt8 DEFAULT 0
     ) engine=ReplicatedMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
-    ORDER BY (timeInserted, flowEndSeconds)
-    TTL timeInserted + INTERVAL 12 HOUR
-    SETTINGS merge_with_ttl_timeout = 14400;
+    ORDER BY (timeInserted, flowEndSeconds);
 
     --Move data from old table and drop old tables
     INSERT INTO flows_local SELECT * FROM flows;
@@ -136,6 +134,12 @@ data:
     --Move data from old table and drop the old table
     INSERT INTO recommendations_local SELECT * FROM recommendations;
     DROP TABLE recommendations;
+
+    CREATE TABLE IF NOT EXISTS flows AS flows_local
+    engine=Distributed('{cluster}', default, flows_local, rand());
+
+    CREATE TABLE IF NOT EXISTS recommendations AS recommendations_local
+    engine=Distributed('{cluster}', default, recommendations_local, rand());
   000002_0-2-0.down.sql: |
     --Alter table to drop new columns
     ALTER TABLE flows
@@ -222,9 +226,10 @@ data:
             clusterUUID String,
             trusted UInt8 DEFAULT 0
         ) engine=ReplicatedMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
-        ORDER BY (timeInserted, flowEndSeconds)
-        TTL timeInserted + INTERVAL 12 HOUR
-        SETTINGS merge_with_ttl_timeout = 14400;
+        ORDER BY (timeInserted, flowEndSeconds);
+
+        ALTER TABLE flows_local MODIFY TTL timeInserted + INTERVAL 12 HOUR;
+        ALTER TABLE flows_local MODIFY SETTING merge_with_ttl_timeout=14400;
 
         --Create a Materialized View to aggregate data for pods
         CREATE MATERIALIZED VIEW IF NOT EXISTS flows_pod_view_local
@@ -245,8 +250,6 @@ data:
             sourceTransportPort,
             destinationTransportPort,
             clusterUUID)
-        TTL timeInserted + INTERVAL 12 HOUR
-        SETTINGS merge_with_ttl_timeout = 14400
         POPULATE
         AS SELECT
             timeInserted,
@@ -288,6 +291,9 @@ data:
             destinationTransportPort,
             clusterUUID;
 
+        ALTER TABLE ".inner.flows_pod_view_local" MODIFY TTL timeInserted + INTERVAL 12 HOUR;
+        ALTER TABLE ".inner.flows_pod_view_local" MODIFY SETTING merge_with_ttl_timeout=14400;
+
         --Create a Materialized View to aggregate data for nodes
         CREATE MATERIALIZED VIEW IF NOT EXISTS flows_node_view_local
         ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
@@ -301,8 +307,6 @@ data:
             sourcePodNamespace,
             destinationPodNamespace,
             clusterUUID)
-        TTL timeInserted + INTERVAL 12 HOUR
-        SETTINGS merge_with_ttl_timeout = 14400
         POPULATE
         AS SELECT
             timeInserted,
@@ -333,6 +337,9 @@ data:
             sourcePodNamespace,
             destinationPodNamespace,
             clusterUUID;
+
+        ALTER TABLE ".inner.flows_node_view_local" MODIFY TTL timeInserted + INTERVAL 12 HOUR;
+        ALTER TABLE ".inner.flows_node_view_local" MODIFY SETTING merge_with_ttl_timeout=14400;
 
         --Create a Materialized View to aggregate data for network policies
         CREATE MATERIALIZED VIEW IF NOT EXISTS flows_policy_view_local
@@ -358,8 +365,6 @@ data:
             destinationServicePortName,
             destinationIP,
             clusterUUID)
-        TTL timeInserted + INTERVAL 12 HOUR
-        SETTINGS merge_with_ttl_timeout = 14400
         POPULATE
         AS SELECT
             timeInserted,
@@ -412,6 +417,9 @@ data:
             destinationServicePortName,
             destinationIP,
             clusterUUID;
+
+        ALTER TABLE ".inner.flows_policy_view_local" MODIFY TTL timeInserted + INTERVAL 12 HOUR;
+        ALTER TABLE ".inner.flows_policy_view_local" MODIFY SETTING merge_with_ttl_timeout=14400;
 
         --Create a table to store the network policy recommendation results
         CREATE TABLE IF NOT EXISTS recommendations_local (

--- a/plugins/clickhouse-schema-management/main.go
+++ b/plugins/clickhouse-schema-management/main.go
@@ -269,7 +269,7 @@ func getDataVersionBasedOnTables() (string, error) {
 	var tableName string
 	var version string
 	command := "SHOW TABLES"
-	var containsNewVersionTable, containsFlows bool
+	var containsFlowsLocal, containsFlows bool
 	if err := wait.PollImmediate(queryRetryInterval, queryTimeout, func() (bool, error) {
 		rows, err := connect.Query(command)
 		if err != nil {
@@ -279,7 +279,6 @@ func getDataVersionBasedOnTables() (string, error) {
 				if err := rows.Scan(&tableName); err != nil {
 					return false, nil
 				}
-				klog.Info(tableName)
 				if tableName == "migrate_version" {
 					var versionFromOldTable string
 					err = connect.QueryRow("SELECT * FROM migrate_version").Scan(&versionFromOldTable)
@@ -293,8 +292,8 @@ func getDataVersionBasedOnTables() (string, error) {
 				if tableName == "flows" {
 					containsFlows = true
 				}
-				if tableName == "schema_migrations" {
-					containsNewVersionTable = true
+				if tableName == "flows_local" {
+					containsFlowsLocal = true
 				}
 			}
 			return true, nil
@@ -302,7 +301,7 @@ func getDataVersionBasedOnTables() (string, error) {
 	}); err != nil {
 		return version, err
 	}
-	if containsFlows && !containsNewVersionTable {
+	if containsFlows && !containsFlowsLocal {
 		version = "0.1.0"
 	}
 	return version, nil

--- a/plugins/clickhouse-schema-management/main_test.go
+++ b/plugins/clickhouse-schema-management/main_test.go
@@ -167,7 +167,7 @@ func checkMigrations(t *testing.T) {
 			name:                "Upgrading from v0.2.0 to v0.4.0",
 			ms:                  migrationSequence{mr("CREATE 2")},
 			setDataVersion:      func() {},
-			showTablesRows:      sqlmock.NewRows([]string{"table"}).AddRow("flows").AddRow("migrate_version").AddRow("schema_migrations"),
+			showTablesRows:      sqlmock.NewRows([]string{"table"}).AddRow("flows").AddRow("migrate_version").AddRow("flows_local"),
 			oldVersionTablesRow: sqlmock.NewRows([]string{"version"}).AddRow("0.2.0"),
 		},
 		{
@@ -181,7 +181,7 @@ func checkMigrations(t *testing.T) {
 		{
 			name:           "No migration",
 			ms:             migrationSequence{},
-			showTablesRows: sqlmock.NewRows([]string{"table"}).AddRow("flows").AddRow("schema_migrations"),
+			showTablesRows: sqlmock.NewRows([]string{"table"}).AddRow("flows").AddRow("schema_migrations").AddRow("flows_local"),
 			setDataVersion: func() {
 				databaseInstance.SetVersion(2, false)
 			},


### PR DESCRIPTION
This PR fixes some bugs regarding ClickHouse data schema upgrading

- Set TTL in a separate command instead of in table creation command to avoid TTL not being updated when table is already created
- Fixed some bugs in data schema management to make sure upgrading from v0.1.0 to v0.3.0 is correct


Signed-off-by: Yanjun Zhou <zhouya@vmware.com>