### PR TITLE
Enhance user experience

### DIFF
--- a/pkg/theia/commands/policy_recommendation_retrieve.go
+++ b/pkg/theia/commands/policy_recommendation_retrieve.go
@@ -92,6 +92,7 @@ func policyRecommendationRetrieve(cmd *cobra.Command, args []string) error {
 		if err := os.WriteFile(filePath, []byte(npr.Status.RecommendedNetworkPolicy), 0600); err != nil {
 			return fmt.Errorf("error when writing recommendation result to file: %v", err)
 		}
+		return nil
 	}
 	if npr.Status.RecommendedNetworkPolicy != "" {
 		fmt.Print(npr.Status.RecommendedNetworkPolicy)

--- a/pkg/theia/commands/policy_recommendation_retrieve_test.go
+++ b/pkg/theia/commands/policy_recommendation_retrieve_test.go
@@ -118,12 +118,6 @@ func TestPolicyRecommendationRetrieve(t *testing.T) {
 			os.Stdout = w
 			err := policyRecommendationRetrieve(cmd, []string{})
 			if tt.expectedErrorMsg == "" {
-				assert.NoError(t, err)
-				outcome := readStdout(t, r, w)
-				os.Stdout = orig
-				for _, msg := range tt.expectedMsg {
-					assert.Contains(t, outcome, msg)
-				}
 				if tt.filePath != "" {
 					result, err := os.ReadFile(tt.filePath)
 					assert.NoError(t, err)
@@ -131,6 +125,13 @@ func TestPolicyRecommendationRetrieve(t *testing.T) {
 						assert.Contains(t, string(result), msg)
 					}
 					defer os.RemoveAll(tt.filePath)
+				} else {
+					assert.NoError(t, err)
+					outcome := readStdout(t, r, w)
+					os.Stdout = orig
+					for _, msg := range tt.expectedMsg {
+						assert.Contains(t, outcome, msg)
+					}
 				}
 			} else {
 				assert.Error(t, err)

--- a/pkg/theia/commands/policy_recommendation_run.go
+++ b/pkg/theia/commands/policy_recommendation_run.go
@@ -244,13 +244,14 @@ Job is still running. Please check completion status for job via CLI later.`, ne
 			}
 			return err
 		}
-		if npr.Status.RecommendedNetworkPolicy != "" {
-			fmt.Print(npr.Status.RecommendedNetworkPolicy)
-		}
 		if filePath != "" {
 			if err := os.WriteFile(filePath, []byte(npr.Status.RecommendedNetworkPolicy), 0600); err != nil {
 				return fmt.Errorf("error when writing recommendation result to file: %v", err)
 			}
+			return nil
+		}
+		if npr.Status.RecommendedNetworkPolicy != "" {
+			fmt.Print(npr.Status.RecommendedNetworkPolicy)
 		}
 		return nil
 	} else {

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -30,7 +30,7 @@ const (
 func GetPodNamespace() string {
 	podNamespace := os.Getenv(podNamespaceEnvKey)
 	if podNamespace == "" {
-		klog.Warningf("Environment variable %s not found", podNamespaceEnvKey)
+		klog.V(2).InfoS("Environment variable not found", "Environment Key", podNamespaceEnvKey)
 	}
 	return podNamespace
 }
@@ -41,8 +41,7 @@ func GetPodNamespace() string {
 func GetTheiaNamespace() string {
 	namespace := GetPodNamespace()
 	if namespace == "" {
-		klog.Warningf("Failed to get Pod Namespace from environment. Using \"%s\" as the "+
-			"Theia Service Namespace", defaultTheiaNamespace)
+		klog.V(2).InfoS("Failed to get Pod Namespace from environment. Using default Theia namespace", "namespace", defaultTheiaNamespace)
 		namespace = defaultTheiaNamespace
 	}
 	return namespace


### PR DESCRIPTION
This PR enhance the user experience when user use theia cli.
1. Increase the verbosity to prevent cli from printing not helpful message generated by util/env.go
2. When user use cli to use "policy-recommendation run" or "policy-recommendation retrieve" with --file option, we don't print the recommended result.

Signed-off-by: Yun-Tang Hsu <hsuy@vmware.com>