### PR TITLE
Improvement for TestPolicyRecommendation e2e test

### DIFF
--- a/test/e2e/policyrecommendation_test.go
+++ b/test/e2e/policyrecommendation_test.go
@@ -175,6 +175,10 @@ func testPolicyRecommendationRun(t *testing.T, data *TestData) {
 	require.NoError(t, err)
 	assert := assert.New(t)
 	assert.Containsf(stdout, fmt.Sprintf("Successfully created policy recommendation job with name %s", jobName), "stdout: %s", stdout)
+	err = data.podWaitForReady(defaultTimeout, jobName+"-driver", flowVisibilityNamespace)
+	require.NoError(t, err)
+	_, err = deleteJob(t, data, jobName)
+	require.NoError(t, err)
 }
 
 // Example output: Status of this policy recommendation job is COMPLETED
@@ -185,6 +189,10 @@ func testPolicyRecommendationStatus(t *testing.T, data *TestData) {
 	require.NoError(t, err)
 	assert := assert.New(t)
 	assert.Containsf(stdout, "Status of this policy recommendation job is", "stdout: %s", stdout)
+	err = data.podWaitForReady(defaultTimeout, jobName+"-driver", flowVisibilityNamespace)
+	require.NoError(t, err)
+	_, err = deleteJob(t, data, jobName)
+	require.NoError(t, err)
 }
 
 // Example output:
@@ -203,11 +211,17 @@ func testPolicyRecommendationList(t *testing.T, data *TestData) {
 	assert.Containsf(stdout, "Name", "stdout: %s", stdout)
 	assert.Containsf(stdout, "Status", "stdout: %s", stdout)
 	assert.Containsf(stdout, jobName, "stdout: %s", stdout)
+	err = data.podWaitForReady(defaultTimeout, jobName+"-driver", flowVisibilityNamespace)
+	require.NoError(t, err)
+	_, err = deleteJob(t, data, jobName)
+	require.NoError(t, err)
 }
 
 // Example output: Successfully deleted policy recommendation job with name pr-e998433e-accb-4888-9fc8-06563f073e86
 func testPolicyRecommendationDelete(t *testing.T, data *TestData) {
 	_, jobName, err := runJob(t, data)
+	require.NoError(t, err)
+	err = data.podWaitForReady(defaultTimeout, jobName+"-driver", flowVisibilityNamespace)
 	require.NoError(t, err)
 	stdout, err := deleteJob(t, data, jobName)
 	require.NoError(t, err)
@@ -237,6 +251,8 @@ func testPolicyRecommendationFailed(t *testing.T, data *TestData) {
 	})
 	require.NoError(t, err)
 	driverPodName := fmt.Sprintf("%s-driver", jobName)
+	err = data.podWaitForReady(defaultTimeout, driverPodName, flowVisibilityNamespace)
+	require.NoError(t, err)
 	if err := data.DeletePod(flowVisibilityNamespace, driverPodName); err != nil {
 		t.Logf("Error when deleting Driver Pod: %v", err)
 	}
@@ -252,6 +268,8 @@ func testPolicyRecommendationFailed(t *testing.T, data *TestData) {
 	require.NoError(t, err)
 	assert := assert.New(t)
 	assert.Truef(strings.Contains(stdout, "error message: driver pod not found") || strings.Contains(stdout, "error message: driver container failed") || strings.Contains(stdout, "error message: driver container status missing"), "stdout: %s", stdout)
+	_, err = deleteJob(t, data, jobName)
+	require.NoError(t, err)
 }
 
 // Example output:


### PR DESCRIPTION
This PR improves the e2e test when running TestPolicyRecommendation.

Previously, subtest testPolicyRecommendationRun/testPolicyRecommendationStatus/testPolicyRecommendationList/testPolicyRecommendationFailed would create npr jobs. But after these tests ended, these created jobs were not deleted, which increased the loading in kind cluster and the test time it took.

Add deletion of npr job at the end of each subtest to decrease the loading of kind cluster.

![image](https://user-images.githubusercontent.com/59460118/197906690-e4d94591-5693-4366-82df-682443aecc0b.png)


Signed-off-by: Yun-Tang Hsu <hsuy@vmware.com>