### PR TITLE
[e2e] Increase 'submit' and 'failed' timeout for Spark jobs.

### DIFF
--- a/test/e2e/policyrecommendation_test.go
+++ b/test/e2e/policyrecommendation_test.go
@@ -30,9 +30,9 @@ import (
 const (
 	// Use a long timeout as it takes ~500s to complete a single Spark job on
 	// Kind testbed
-	jobCompleteTimeout = 10 * time.Minute
-	jobSubmitTimeout   = 2 * time.Minute
-	jobFailedTimeout   = 2 * time.Minute
+	jobCompleteTimeout = 15 * time.Minute
+	jobSubmitTimeout   = 4 * time.Minute
+	jobFailedTimeout   = 4 * time.Minute
 	startCmd           = "./theia policy-recommendation run"
 	statusCmd          = "./theia policy-recommendation status"
 	listCmd            = "./theia policy-recommendation list"


### PR DESCRIPTION
Tests seem to be failing intermittently due to timeout issues. This changes allows for more time to wait for jobs to complete or fail.