### PR TITLE
Fix the ingestion error of snowflake on Pod label fields

### DIFF
--- a/snowflake/pkg/infra/stack.go
+++ b/snowflake/pkg/infra/stack.go
@@ -292,7 +292,8 @@ func declareSnowflakeDatabase(
 			AutoIngest:       pulumi.Bool(true),
 			ErrorIntegration: notificationIntegration.ID(),
 			// FQN required for table and stage, see https://github.com/pulumi/pulumi-snowflake/issues/129
-			CopyStatement: pulumi.Sprintf("COPY INTO %s.%s.%s FROM @%s.%s.%s FILE_FORMAT = (TYPE = 'CSV')", databaseName, schemaName, flowsTableName, databaseName, schemaName, ingestionStageName),
+			// 0x27 is the hex representation of single quote. We use it to enclose Pod labels string.
+			CopyStatement: pulumi.Sprintf("COPY INTO %s.%s.%s FROM @%s.%s.%s FILE_FORMAT = (TYPE = CSV FIELD_OPTIONALLY_ENCLOSED_BY='0x27')", databaseName, schemaName, flowsTableName, databaseName, schemaName, ingestionStageName),
 		}, pulumi.Parent(schema), pulumi.DependsOn([]pulumi.Resource{ingestionStage, dbMigrations}), pulumi.DeleteBeforeReplace(true))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
In this commit, we fix the ingestion error of snowpipe on flow records with Pod label fields. The reason behind this error is commas are used to separate different columns in CSV and Pod label columns contain commas so they are separated into multiple columns when ingested into snowflake.
To fix it, we add a customized file format for flow records and use single quote enclosing Pod label fields.

Changes on Antrea side: https://github.com/antrea-io/antrea/pull/4334