### PR TITLE
Add theia-sf (Theia Snowflake) CLI to release assets

### DIFF
--- a/.github/workflows/process_release.yml
+++ b/.github/workflows/process_release.yml
@@ -74,6 +74,51 @@ jobs:
         asset_path: ./assets/theia-windows-x86_64.exe
         asset_name: theia-windows-x86_64.exe
         asset_content_type: application/octet-stream
+    - name: Upload theia-sf-darwin-x86_64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/theia-sf-darwin-x86_64
+        asset_name: theia-sf-darwin-x86_64
+        asset_content_type: application/octet-stream
+    - name: Upload theia-sf-linux-arm
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/theia-sf-linux-arm
+        asset_name: theia-sf-linux-arm
+        asset_content_type: application/octet-stream
+    - name: Upload theia-sf-linux-arm64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/theia-sf-linux-arm64
+        asset_name: theia-sf-linux-arm64
+        asset_content_type: application/octet-stream
+    - name: Upload theia-sf-linux-x86_64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/theia-sf-linux-x86_64
+        asset_name: theia-sf-linux-x86_64
+        asset_content_type: application/octet-stream
+    - name: Upload theia-sf-windows-x86_64.exe
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/theia-sf-windows-x86_64.exe
+        asset_name: theia-sf-windows-x86_64.exe
+        asset_content_type: application/octet-stream
     - name: Upload Theia Helm chart archive
       uses: actions/upload-release-asset@v1
       env:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GO_VERSION            := $(shell head -n 1 build/images/deps/go-version)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=$(GO_VERSION)
 
 .PHONY: all
-all: build
+all: theia
 
 include versioning.mk
 
@@ -122,7 +122,7 @@ clean:
 codegen:
 	@echo "===> Updating generated code <==="
 	$(CURDIR)/hack/update-codegen.sh
-	
+
 .PHONY: manifest
 manifest:
 	@echo "===> Generating dev manifest for Theia <==="

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -67,6 +67,8 @@ for build in "${THEIA_BUILDS[@]}"; do
     # for native builds. We ensure it is always disabled for portability since
     # these binaries will be distributed as release assets.
     GOOS=$os GOARCH=$arch CGO_ENABLED=0 THEIA_BINARY_NAME="theia-$suffix" BINDIR="$OUTPUT_DIR"/ make theia-release
+
+    GOOS=$os GOARCH=$arch CGO_ENABLED=0 CLI_BINARY_NAME="theia-sf-$suffix" BINDIR="$OUTPUT_DIR"/ make -C snowflake bin
 done
 
 

--- a/snowflake/.gitignore
+++ b/snowflake/.gitignore
@@ -1,1 +1,2 @@
 creds
+*.zip

--- a/snowflake/Makefile
+++ b/snowflake/Makefile
@@ -1,7 +1,21 @@
 GO                 ?= go
-BINDIR := $(CURDIR)/bin
+LDFLAGS            :=
+GOFLAGS            :=
+BINDIR             ?= $(CURDIR)/bin
+CLI_BINARY_NAME    ?= theia-sf
 
+.PHONY: all
 all: udfs bin
+
+VERSION_FILE := ../VERSION
+include ../versioning.mk
+
+VERSION_LDFLAGS = -X antrea.io/theia/snowflake/pkg/version.Version=$(VERSION)
+VERSION_LDFLAGS += -X antrea.io/theia/snowflake/pkg/version.GitSHA=$(GIT_SHA)
+VERSION_LDFLAGS += -X antrea.io/theia/snowflake/pkg/version.GitTreeState=$(GIT_TREE_STATE)
+VERSION_LDFLAGS += -X antrea.io/theia/snowflake/pkg/version.ReleaseStatus=$(RELEASE_STATUS)
+
+LDFLAGS += $(VERSION_LDFLAGS)
 
 .PHONY: udfs
 udfs:
@@ -9,7 +23,7 @@ udfs:
 
 .PHONY: bin
 bin:
-	$(GO) build -o $(BINDIR)/theia-sf antrea.io/theia/snowflake
+	$(GO) build -o $(BINDIR)/$(CLI_BINARY_NAME) $(GOFLAGS) -ldflags '-s -w $(LDFLAGS)' antrea.io/theia/snowflake
 
 .PHONY: .coverage
 .coverage:
@@ -25,8 +39,7 @@ test-unit: .coverage
 
 .PHONY: generate
 generate:
-	MOCKGEN_COPYRIGHT_FILE=$(CURDIR)/hack/boilerplate/license_header.raw.txt \
-	$(GO) generate ./...
+        MOCKGEN_COPYRIGHT_FILE=$(CURDIR)/hack/boilerplate/license_header.raw.txt $(GO) generate ./...
 
 .PHONY: clean
 clean:

--- a/snowflake/cmd/version.go
+++ b/snowflake/cmd/version.go
@@ -1,0 +1,36 @@
+// Copyright 2022 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd
+
+import (
+	"fmt"
+
+	"antrea.io/theia/snowflake/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show CLI version",
+	Long: `Show CLI version, which is the Theia version for which this CLI
+was built.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version.GetFullVersionWithRuntimeInfo())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/snowflake/pkg/version/version.go
+++ b/snowflake/pkg/version/version.go
@@ -1,0 +1,73 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/blang/semver"
+)
+
+// These variables are set at build-time.
+var (
+	// Must follow the rules in https://semver.org/
+	// Does not include git / build information
+	Version = ""
+	// Empty if git not available
+	GitSHA = ""
+	// Can be "dirty", "clean" or empty (if git not available)
+	GitTreeState = ""
+	// Can be "unreleased" or "released"; if it is "unreleased" then we add build information to
+	// the version in GetFullVersion
+	ReleaseStatus = "unreleased"
+)
+
+func GetVersion() semver.Version {
+	v, _ := semver.Parse(Version[1:])
+	return v
+}
+
+func GetGitSHA() string {
+	return GitSHA
+}
+
+// GetFullVersion returns the version string to be displayed by executables. It will look like
+// "<major>.<minor>.<patch>" for released versions and "<major>.<minor>.<patch>-<SHA>[.dirty]" for
+// unreleased versions.
+func GetFullVersion() string {
+	if Version == "" {
+		return "UNKNOWN"
+	}
+	if ReleaseStatus == "released" {
+		return Version
+	}
+	// add build information
+	if GitSHA == "" {
+		return fmt.Sprintf("%s-unknown", Version)
+	}
+	if GitTreeState == "dirty" {
+		return fmt.Sprintf("%s-%s.dirty", Version, GitSHA)
+	}
+	return fmt.Sprintf("%s-%s", Version, GitSHA)
+}
+
+// GetFullVersionWithRuntimeInfo returns the same version string as GetFullVersion but appends
+// "<GOOS>/<GOARCH> <GOVERSION>", where GOOS is the running program's operating system target
+// (e.g. darwin, linux), GOARCH is the the running program's architecture target (e.g. amd64), and
+// GOVERSION is the Go version used to build the current binary.
+func GetFullVersionWithRuntimeInfo() string {
+	return fmt.Sprintf("%s %s/%s %s", GetFullVersion(), runtime.GOOS, runtime.GOARCH, runtime.Version())
+}

--- a/versioning.mk
+++ b/versioning.mk
@@ -1,9 +1,17 @@
+VERSION_FILE ?= VERSION
 # check if git is available
 ifeq ($(shell which git),)
+        $(warning git is not available, binaries will not include git SHA)
+        GIT_SHA :=
+        GIT_TREE_STATE :=
+        GIT_TAG :=
         VERSION_SUFFIX := unknown
 else
+        GIT_SHA := $(shell git rev-parse --short HEAD)
         # Tree state is "dirty" if there are uncommitted changes, untracked files are ignored
         GIT_TREE_STATE := $(shell test -n "`git status --porcelain --untracked-files=no`" && echo "dirty" || echo "clean")
+        # Empty string if we are not building a tag
+        GIT_TAG := $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
         ifeq ($(GIT_TREE_STATE),dirty)
                 VERSION_SUFFIX := $(GIT_SHA).dirty
         else
@@ -11,8 +19,17 @@ else
         endif
 endif
 
+# if building a tag or VERSION is set, set RELEASE_STATUS to "released"
+ifdef VERSION
+        RELEASE_STATUS := released
+else ifneq ($(GIT_TAG),)
+        RELEASE_STATUS := released
+else
+        RELEASE_STATUS := unreleased
+endif
+
 ifndef VERSION
-        VERSION := $(shell head -n 1 VERSION)
+        VERSION := $(shell head -n 1 $(VERSION_FILE))
         DOCKER_IMG_VERSION := $(VERSION)-$(VERSION_SUFFIX)
 else
         DOCKER_IMG_VERSION := $(VERSION)
@@ -21,4 +38,7 @@ endif
 version-info:
 	@echo "===> Version information <==="
 	@echo "VERSION: $(VERSION)"
+	@echo "GIT_SHA: $(GIT_SHA)"
+	@echo "GIT_TREE_STATE: $(GIT_TREE_STATE)"
+	@echo "RELEASE_STATUS: $(RELEASE_STATUS)"
 	@echo "DOCKER_IMG_VERSION: $(DOCKER_IMG_VERSION)"


### PR DESCRIPTION
We also add a new CLI command (theia-sf version) to display the Theia version from which the CLI was built.

Signed-off-by: Antonin Bas <abas@vmware.com>