### PR TITLE
Resync Theia Manager at startup

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -147,7 +147,6 @@ func installAPIGroup(s *TheiaManagerAPIServer, c Config) error {
 	groups := []*genericapiserver.APIGroupInfo{&intelligenceGroup, &statsGroup, &systemGroup}
 
 	for _, apiGroupInfo := range groups {
-		klog.Info(apiGroupInfo)
 		if err := s.GenericAPIServer.InstallAPIGroup(apiGroupInfo); err != nil {
 			return err
 		}

--- a/pkg/apiserver/registry/intelligence/networkpolicyrecommendation/rest.go
+++ b/pkg/apiserver/registry/intelligence/networkpolicyrecommendation/rest.go
@@ -187,7 +187,7 @@ func (r *REST) copyNetworkPolicyRecommendation(intelli *intelligence.NetworkPoli
 
 func (r *REST) getRecommendationResult(id string) (result string, err error) {
 	if r.clickhouseConnect == nil {
-		r.clickhouseConnect, err = setupClickHouseConnection()
+		r.clickhouseConnect, err = setupClickHouseConnection(nil)
 		if err != nil {
 			return result, err
 		}

--- a/pkg/apiserver/registry/intelligence/networkpolicyrecommendation/rest_test.go
+++ b/pkg/apiserver/registry/intelligence/networkpolicyrecommendation/rest_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 
 	crdv1alpha1 "antrea.io/theia/pkg/apis/crd/v1alpha1"
 	intelligence "antrea.io/theia/pkg/apis/intelligence/v1alpha1"
@@ -75,7 +76,7 @@ func TestREST_Get(t *testing.T) {
 			resultRows := sqlmock.NewRows([]string{"policy"}).AddRow(policy1).AddRow(policy2)
 			mock.ExpectQuery("SELECT policy FROM recommendations WHERE id = (?);").WillReturnRows(resultRows)
 
-			setupClickHouseConnection = func() (connect *sql.DB, err error) {
+			setupClickHouseConnection = func(client kubernetes.Interface) (connect *sql.DB, err error) {
 				return db, nil
 			}
 			r := NewREST(&fakeQuerier{})

--- a/pkg/apiserver/utils/stats/clickhouse_stats.go
+++ b/pkg/apiserver/utils/stats/clickhouse_stats.go
@@ -148,7 +148,7 @@ func (c *ClickHouseStatQuerierImpl) GetStackTrace(namespace string, stats *v1alp
 func (c *ClickHouseStatQuerierImpl) getDataFromClickHouse(query int, namespace string, stats *v1alpha1.ClickHouseStats) error {
 	var err error
 	if c.clickhouseConnect == nil {
-		c.clickhouseConnect, err = clickhouse.SetupConnection()
+		c.clickhouseConnect, err = clickhouse.SetupConnection(nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/util/clickhouse/test_utils.go
+++ b/pkg/util/clickhouse/test_utils.go
@@ -1,0 +1,74 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clickhouse
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func CreateFakeClickHouse(t *testing.T, kubeClient kubernetes.Interface, namespace string) (db *sql.DB, mock sqlmock.Sqlmock) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual), sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	openSql = func(driverName, dataSourceName string) (*sql.DB, error) {
+		assert.Equal(t, driverName, "clickhouse")
+		assert.Equal(t, dataSourceName, "tcp://localhost:9000?debug=false&username=username&password=password")
+		return db, nil
+	}
+	clickHousePod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "clickhouse",
+			Namespace: namespace,
+			Labels:    map[string]string{"app": "clickhouse"},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	}
+	kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), clickHousePod, metav1.CreateOptions{})
+	clickHouseService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ServiceName,
+			Namespace: namespace,
+		},
+		Spec: v1.ServiceSpec{
+			Ports:     []v1.ServicePort{{Port: 9000, Protocol: ServicePortProtocal}},
+			ClusterIP: "localhost",
+		},
+	}
+	kubeClient.CoreV1().Services(namespace).Create(context.TODO(), clickHouseService, metav1.CreateOptions{})
+	clickhouseSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      SecretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"username": []byte("username"),
+			"password": []byte("password"),
+		},
+	}
+	kubeClient.CoreV1().Secrets(namespace).Create(context.TODO(), clickhouseSecret, metav1.CreateOptions{})
+	mock.ExpectPing()
+	return db, mock
+}

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1245,7 +1245,7 @@ func (data *TestData) waitForClickHousePod() error {
 	if err == wait.ErrWaitTimeout {
 		clickHousePodName := fmt.Sprintf("%s-0-0-0", clickHousePodNamePrefix)
 		_, stdout, _, _ := data.provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s describe pod %s", flowVisibilityNamespace, clickHousePodName))
-		return fmt.Errorf("ClickHouse StatefulSet not ready within %v; kubectl describe pod output: %v", defaultTimeout, stdout)
+		return fmt.Errorf("ClickHouse StatefulSet not ready within %v; kubectl describe pod output: %v", defaultTimeout*2, stdout)
 	} else if err != nil {
 		return err
 	}


### PR DESCRIPTION
Theia Manager needs to be resynchronized with the SparkApplications and
db entries when it recovers from the downtime. This commit

- Supports removing stale SparkApplications and db entries after Theia Manager restart
- Supports adding back scheduled/running NPR to periodical sync list
- Adds e2e tests for the Theia Manager restart

Fixes #135 

Signed-off-by: Yanjun Zhou <zhouya@vmware.com>