### PR TITLE
Remove unused shell version ClickHouse data migration code 

### DIFF
--- a/build/charts/theia/provisioning/datasources/init.sh
+++ b/build/charts/theia/provisioning/datasources/init.sh
@@ -19,20 +19,5 @@ set -e
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 source $THIS_DIR/create_table.sh
-
-# This function is kept to be compatible with version below v0.3.0
-function setDataVersion {
-    tables=$(clickhouse client -h 127.0.0.1 -q "SHOW TABLES")
-    if [[ $tables == *"migrate_version"* ]]; then
-        clickhouse client -h 127.0.0.1 -q "ALTER TABLE migrate_version DELETE WHERE version!=''"
-    else
-        clickhouse client -h 127.0.0.1 -q "CREATE TABLE migrate_version (version String) engine=MergeTree ORDER BY version"
-    fi
-    clickhouse client -h 127.0.0.1 -q "INSERT INTO migrate_version (*) VALUES ('{{ .Chart.Version }}')"
-    echo "=== Set data schema version to {{ .Chart.Version }} ==="
-}
-
 ../clickhouse-schema-management
 createTable
-setDataVersion
-

--- a/build/charts/theia/provisioning/datasources/migrators/downgrade/0-3-0_0-2-0.sql
+++ b/build/charts/theia/provisioning/datasources/migrators/downgrade/0-3-0_0-2-0.sql
@@ -1,5 +1,0 @@
---Alter table to drop new columns
-ALTER TABLE flows
-DROP clusterUUID String;
-ALTER TABLE flows_local
-DROP clusterUUID String;

--- a/build/charts/theia/templates/_helpers.tpl
+++ b/build/charts/theia/templates/_helpers.tpl
@@ -78,10 +78,6 @@
       - key: {{ regexReplaceAll "(.*)/" $path "" }}
         path: {{ regexReplaceAll "(.*)/" $path "" }}
       {{- end }}
-      {{- range $path, $_ :=  $Files.Glob  "provisioning/datasources/migrators/downgrade/*" }}
-      - key: {{ regexReplaceAll "(.*)/" $path "" }}
-        path: migrators/downgrade/{{ regexReplaceAll "(.*)/" $path "" }}
-      {{- end }}
       {{- range $path, $_ :=  $Files.Glob  "provisioning/datasources/migrators/*.sql" }}
       - key: {{ regexReplaceAll "(.*)/" $path "" }}
         path: migrators/{{ regexReplaceAll "(.*)/" $path "" }}

--- a/build/charts/theia/templates/clickhouse/configmap.yaml
+++ b/build/charts/theia/templates/clickhouse/configmap.yaml
@@ -5,5 +5,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
 {{ tpl (.Files.Glob "provisioning/datasources/*.sh").AsConfig . | indent 2 }}
-{{ tpl (.Files.Glob "provisioning/datasources/migrators/downgrade/*").AsConfig . | indent 2 }}
 {{ (.Files.Glob "provisioning/datasources/migrators/*.sql").AsConfig | indent 2 }}

--- a/build/yamls/flow-visibility.yml
+++ b/build/yamls/flow-visibility.yml
@@ -53,12 +53,6 @@ subjects:
 ---
 apiVersion: v1
 data:
-  0-3-0_0-2-0.sql: |
-    --Alter table to drop new columns
-    ALTER TABLE flows
-    DROP clusterUUID String;
-    ALTER TABLE flows_local
-    DROP clusterUUID String;
   000001_0-1-0.down.sql: ""
   000001_0-1-0.up.sql: |
     --Create a table to store records
@@ -482,7 +476,7 @@ data:
         engine=Distributed('{cluster}', default, recommendations_local, rand());
     EOSQL
     }
-  init.sh: |+
+  init.sh: |
     #!/usr/bin/env bash
 
     # Copyright 2022 Antrea Authors.
@@ -504,23 +498,8 @@ data:
     THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
     source $THIS_DIR/create_table.sh
-
-    # This function is kept to be compatible with version below v0.3.0
-    function setDataVersion {
-        tables=$(clickhouse client -h 127.0.0.1 -q "SHOW TABLES")
-        if [[ $tables == *"migrate_version"* ]]; then
-            clickhouse client -h 127.0.0.1 -q "ALTER TABLE migrate_version DELETE WHERE version!=''"
-        else
-            clickhouse client -h 127.0.0.1 -q "CREATE TABLE migrate_version (version String) engine=MergeTree ORDER BY version"
-        fi
-        clickhouse client -h 127.0.0.1 -q "INSERT INTO migrate_version (*) VALUES ('0.5.0')"
-        echo "=== Set data schema version to 0.5.0 ==="
-    }
-
     ../clickhouse-schema-management
     createTable
-    setDataVersion
-
 kind: ConfigMap
 metadata:
   name: clickhouse-mounted-configmap
@@ -6386,8 +6365,6 @@ spec:
               path: create_table.sh
             - key: init.sh
               path: init.sh
-            - key: 0-3-0_0-2-0.sql
-              path: migrators/downgrade/0-3-0_0-2-0.sql
             - key: 000001_0-1-0.down.sql
               path: migrators/000001_0-1-0.down.sql
             - key: 000001_0-1-0.up.sql

--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -239,6 +239,10 @@ you use PersistentVolume for ClickHouse. To downgrade from v0.2 to v0.1, you
 need to uninstall ClickHouse, delete related data if you use PersistenVolume
 and redeploy it.
 
+In v0.3, we add a breaking change to ClickHouse data migration. To downgrade
+from a version after v0.3 to a version before v0.3 without data lossing, please
+first downgrade it to v0.3 and then to the version below v0.3.
+
 A ClickHouse cluster consists of one or more shards. Shards refer to the servers
 that contain different parts of the data. You can deploy multiple shards to scale
 the cluster horizontally. Each shard consists of one or more replica hosts.


### PR DESCRIPTION
We replace the shell version ClickHouse data migration by the Golang version in Theia v0.3.

The unused bash code and migrators for the bash version ClickHouse data migration
are removed in this PR.

Signed-off-by: Yanjun Zhou [zhouya@vmware.com](mailto:zhouya@vmware.com)
