### PR TITLE
Add a version command for theia CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,13 @@ all: theia
 
 include versioning.mk
 
+VERSION_LDFLAGS = -X antrea.io/theia/pkg/version.Version=$(VERSION)
+VERSION_LDFLAGS += -X antrea.io/theia/pkg/version.GitSHA=$(GIT_SHA)
+VERSION_LDFLAGS += -X antrea.io/theia/pkg/version.GitTreeState=$(GIT_TREE_STATE)
+VERSION_LDFLAGS += -X antrea.io/theia/pkg/version.ReleaseStatus=$(RELEASE_STATUS)
+
+LDFLAGS += $(VERSION_LDFLAGS)
+
 UNAME_S := $(shell uname -s)
 
 .PHONY: bin

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/TomCodeLV/OVSDB-golang-lib v0.0.0-20200116135253-9bbdfadcd881 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/hub v1.0.1 // indirect
 	github.com/cenkalti/rpc2 v0.0.0-20180727162946-9642ea02d0aa // indirect

--- a/pkg/theia/commands/version.go
+++ b/pkg/theia/commands/version.go
@@ -1,0 +1,38 @@
+// Copyright 2023 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"antrea.io/theia/pkg/version"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show Theia CLI version",
+	Long: `Show Theia CLI version, which is the Theia version for which this
+CLI was built.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version.GetFullVersionWithRuntimeInfo())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,73 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/blang/semver"
+)
+
+// These variables are set at build-time.
+var (
+	// Must follow the rules in https://semver.org/
+	// Does not include git / build information
+	Version = ""
+	// Empty if git not available
+	GitSHA = ""
+	// Can be "dirty", "clean" or empty (if git not available)
+	GitTreeState = ""
+	// Can be "unreleased" or "released"; if it is "unreleased" then we add build information to
+	// the version in GetFullVersion
+	ReleaseStatus = "unreleased"
+)
+
+func GetVersion() semver.Version {
+	v, _ := semver.Parse(Version[1:])
+	return v
+}
+
+func GetGitSHA() string {
+	return GitSHA
+}
+
+// GetFullVersion returns the version string to be displayed by executables. It will look like
+// "<major>.<minor>.<patch>" for released versions and "<major>.<minor>.<patch>-<SHA>[.dirty]" for
+// unreleased versions.
+func GetFullVersion() string {
+	if Version == "" {
+		return "UNKNOWN"
+	}
+	if ReleaseStatus == "released" {
+		return Version
+	}
+	// add build information
+	if GitSHA == "" {
+		return fmt.Sprintf("%s-unknown", Version)
+	}
+	if GitTreeState == "dirty" {
+		return fmt.Sprintf("%s-%s.dirty", Version, GitSHA)
+	}
+	return fmt.Sprintf("%s-%s", Version, GitSHA)
+}
+
+// GetFullVersionWithRuntimeInfo returns the same version string as GetFullVersion but appends
+// "<GOOS>/<GOARCH> <GOVERSION>", where GOOS is the running program's operating system target
+// (e.g. darwin, linux), GOARCH is the the running program's architecture target (e.g. amd64), and
+// GOVERSION is the Go version used to build the current binary.
+func GetFullVersionWithRuntimeInfo() string {
+	return fmt.Sprintf("%s %s/%s %s", GetFullVersion(), runtime.GOOS, runtime.GOARCH, runtime.Version())
+}


### PR DESCRIPTION
Add a new CLI command (theia version) to display the Theia version from which the theia CLI was built.

Signed-off-by: Yongming Ding <dyongming@vmware.com>