### PR TITLE
Migrate image registry to `registry.k8s.io`

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -103,7 +103,7 @@ fi
 
 trap "quit" INT EXIT
 
-COMMON_IMAGES_LIST=("k8s.gcr.io/e2e-test-images/agnhost:2.29" \
+COMMON_IMAGES_LIST=("registry.k8s.io/e2e-test-images/agnhost:2.29" \
                     "projects.registry.vmware.com/antrea/busybox"  \
                     "projects.registry.vmware.com/antrea/nginx:1.21.6-alpine" \
                     "projects.registry.vmware.com/antrea/perftool" \

--- a/ci/kind/test-upgrade-theia.sh
+++ b/ci/kind/test-upgrade-theia.sh
@@ -150,7 +150,7 @@ else
     CLICKHOUSE_FROM_TAG=$THEIA_FROM_TAG
 fi
 
-DOCKER_IMAGES=("k8s.gcr.io/e2e-test-images/agnhost:2.29" \
+DOCKER_IMAGES=("registry.k8s.io/e2e-test-images/agnhost:2.29" \
                 "projects.registry.vmware.com/antrea/busybox"  \
                 "projects.registry.vmware.com/antrea/nginx:1.21.6-alpine" \
                 "projects.registry.vmware.com/antrea/perftool" \

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -98,7 +98,7 @@ const (
 	clickHouseLocalPvLabel     string = "antrea.io/clickhouse-data-node"
 	clickHouseLocalPvPath      string = "/data/clickhouse"
 
-	agnhostImage  = "k8s.gcr.io/e2e-test-images/agnhost:2.29"
+	agnhostImage  = "registry.k8s.io/e2e-test-images/agnhost:2.29"
 	busyboxImage  = "projects.registry.vmware.com/antrea/busybox"
 	perftoolImage = "projects.registry.vmware.com/antrea/perftool"
 


### PR DESCRIPTION
This PR will migrate image registry from k8s.gcr.io to registry.k8s.io.
Fixes: https://github.com/kubernetes/k8s.io/issues/4780

Signed-off-by: ArkaSaha30 [arkasaha30@gmail.com](mailto:arkasaha30@gmail.com)