### PR TITLE
Bump actions/setup-go from 3 to 4

### DIFF
--- a/.github/workflows/clair.yml
+++ b/.github/workflows/clair.yml
@@ -11,9 +11,10 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
+        cache-dependency-path: '**/go.sum'
     - name: Scan Theia Docker image for vulnerabilities
       run: |
         mkdir clair-reports

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -37,9 +37,10 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         token: ${{ secrets.ANTREA_BOT_WRITE_PAT }}
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
+        cache-dependency-path: '**/go.sum'
     - name: Run go mod tidy
       # the checks above (Github actor and PR labels) ensure that a malicious
       # actor cannot open a PR with a modified "tidy" Makefile target and

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,9 +11,6 @@ on:
     - release-*
     - feature/*
 
-env:
-  go-cache-name: go
-
 jobs:
   check-changes:
     name: Check whether tests need to be run based on diff
@@ -41,23 +38,9 @@ jobs:
     - name: Check-out code
       uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
-    - uses: actions/cache@v3
-      with:
-        # In order:
-        # * Module download cache
-        # * Build cache (Linux)
-        # * Build cache (Mac)
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ env.go-cache-name }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.go-cache-name }}-
     - name: Run unit tests
       run: make test-unit
     - name: Codecov
@@ -94,23 +77,10 @@ jobs:
     - name: Check-out code
       uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'snowflake/go.mod'
-    - uses: actions/cache@v3
-      with:
-        # In order:
-        # * Module download cache
-        # * Build cache (Linux)
-        # * Build cache (Mac)
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ env.go-cache-name }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.go-cache-name }}-
+        cache-dependency-path: 'snowflake/go.sum'
     - name: Run unit tests
       run: |
         cd snowflake
@@ -135,23 +105,10 @@ jobs:
     - name: Check-out code
       uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
-    - uses: actions/cache@v3
-      with:
-        # In order:
-        # * Module download cache
-        # * Build cache (Linux)
-        # * Build cache (Mac)
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ env.go-cache-name }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.go-cache-name }}-
+        cache-dependency-path: '**/go.sum'
     - name: Run golangci-lint
       run: make golangci
 
@@ -164,9 +121,10 @@ jobs:
     - name: Check-out code
       uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
+        cache-dependency-path: '**/go.sum'
     - name: Check tidy
       run: make test-tidy
     - name: Check manifest
@@ -181,9 +139,10 @@ jobs:
     - name: Check-out code
       uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
+        cache-dependency-path: '**/go.sum'
     - name: Run verify scripts
       run: make verify
     - name: Checking for broken Markdown links

--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -35,9 +35,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
+        cache-dependency-path: '**/go.sum'
     - name: Cache licensing information for dependencies
       uses: actions/cache@v3
       id: cache

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -116,7 +116,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           df -h
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
       - name: Download Spark jobs images from previous jobs
@@ -182,7 +182,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           df -h
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
       - name: Download ClickHouse monitor images from previous jobs

--- a/.github/workflows/process_release.yml
+++ b/.github/workflows/process_release.yml
@@ -10,9 +10,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
+        # make sure the latest patch version is used
+        check-latest: true
+        cache-dependency-path: '**/go.sum'
     - name: Build assets
       env:
         TAG: ${{ github.ref }}

--- a/.github/workflows/verify_docs.yml
+++ b/.github/workflows/verify_docs.yml
@@ -13,9 +13,10 @@ jobs:
     - name: Check-out code
       uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
+        cache-dependency-path: '**/go.sum'
     - name: Run verify scripts
       run: make verify
     - name: Checking for broken Markdown links for main branch


### PR DESCRIPTION
The new version of the action enables caching by default.