### PR TITLE
Bump pySpark to 3.3.2 for requirements.txt and dockerfile

### DIFF
--- a/build/images/Dockerfile.spark-jobs.ubuntu
+++ b/build/images/Dockerfile.spark-jobs.ubuntu
@@ -1,4 +1,4 @@
-FROM gcr.io/spark-operator/spark-py:v3.1.1
+FROM apache/spark-py:v3.3.2
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A docker image to deploy policy recommendation and throughput anomaly detection Spark job."
@@ -15,7 +15,6 @@ COPY plugins/policy-recommendation/policy_recommendation_utils.py /opt/spark/wor
 COPY plugins/policy-recommendation/antrea_crd.py /opt/spark/work-dir/antrea_crd.py
 COPY plugins/anomaly-detection/anomaly_detection.py /opt/spark/work-dir/anomaly_detection.py
 COPY plugins/anomaly-detection/requirements.txt /opt/spark/work-dir/anomaly_detection_requirements.txt
-
 
 RUN pip3 install --upgrade pip && \
     pip3 install pyyaml && \

--- a/plugins/policy-recommendation/requirements.txt
+++ b/plugins/policy-recommendation/requirements.txt
@@ -1,4 +1,4 @@
 kubernetes==18.20.0
-pyspark==3.1.2
+pyspark==3.3.2
 pytest==6.2.5
 PyYAML==6.0


### PR DESCRIPTION
- Updating the docker image as previous spark image was limited to 3.1.1
- Updating requirements.txt to keep the tests consistent.