### PR TITLE
Add ping retry when connecting clickhouse from theia-manager

### DIFF
--- a/pkg/apiserver/registry/stats/clickhouse/rest.go
+++ b/pkg/apiserver/registry/stats/clickhouse/rest.go
@@ -49,33 +49,41 @@ func (r *REST) New() runtime.Object {
 
 func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	var status v1alpha1.ClickHouseStats
-	var err error
 	switch name {
 	case "diskInfo":
-		err = r.clickHouseStatusQuerier.GetDiskInfo(defaultNameSpace, &status)
+		err := r.clickHouseStatusQuerier.GetDiskInfo(defaultNameSpace, &status)
+		if err != nil {
+			return nil, fmt.Errorf("error when sending diskInfo query to ClickHouse: %s", err)
+		}
 		if status.DiskInfos == nil {
 			return nil, fmt.Errorf("no diskInfo data is returned by database")
 		}
 	case "tableInfo":
-		err = r.clickHouseStatusQuerier.GetTableInfo(defaultNameSpace, &status)
+		err := r.clickHouseStatusQuerier.GetTableInfo(defaultNameSpace, &status)
+		if err != nil {
+			return nil, fmt.Errorf("error when sending tableInfo query to ClickHouse: %s", err)
+		}
 		if status.TableInfos == nil {
 			return nil, fmt.Errorf("no tableInfo data is returned by database")
 		}
 	case "insertRate":
-		err = r.clickHouseStatusQuerier.GetInsertRate(defaultNameSpace, &status)
+		err := r.clickHouseStatusQuerier.GetInsertRate(defaultNameSpace, &status)
+		if err != nil {
+			return nil, fmt.Errorf("error when sending insertRate query to ClickHouse: %s", err)
+		}
 		if status.InsertRates == nil {
 			return nil, fmt.Errorf("no insertRate data is returned by database")
 		}
 	case "stackTrace":
-		err = r.clickHouseStatusQuerier.GetStackTrace(defaultNameSpace, &status)
+		err := r.clickHouseStatusQuerier.GetStackTrace(defaultNameSpace, &status)
+		if err != nil {
+			return nil, fmt.Errorf("error when sending stackTrace query to ClickHouse: %s", err)
+		}
 		if status.StackTraces == nil {
 			return nil, fmt.Errorf("no stackTrace data is returned by database")
 		}
 	default:
 		return nil, fmt.Errorf("cannot recognize the statua name: %s", name)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("error when sending query to ClickHouse: %s", err)
 	}
 	return &status, nil
 }

--- a/test/e2e/theia_clickhouse_test.go
+++ b/test/e2e/theia_clickhouse_test.go
@@ -226,7 +226,7 @@ func getClickHouseDBInfo(t *testing.T, data *TestData, query string) (stdout str
 	rc, stdout, stderr, err = data.RunCommandOnNode(controlPlaneNodeName(), query)
 
 	if err != nil || rc != 0 {
-		return "", fmt.Errorf("error when running %s from %s: %v\nstdout:%s\nstderr:%s", cmd, controlPlaneNodeName(), err, stdout, stderr)
+		return "", fmt.Errorf("error when running %s from %s: %v\nstdout:%s\nstderr:%s", query, controlPlaneNodeName(), err, stdout, stderr)
 	}
 	return strings.TrimSuffix(stdout, "\n"), nil
 }


### PR DESCRIPTION
In this PR, we add retry in connect function for theia-manager and print more detailed descriptions when we get error from theia-manager. 

We are using env variable "CLICKHOUSE_URL"=clickhouse-clickhouse.flow-visibility.svc.cluster.local when connecting to clickhouse from theia-manager. However, kube-dns is unstable for few seconds when a new service is added. Adding retry can prevent theia-manager from directly sending error back to the user when ping is temporarily failed.


```root@theia-manager-8cc849956-x74kh:/# nslookup
clickhouse-clickhouse.flow-visibility.svc.cluster.local
Server:		10.96.0.10
Address:	10.96.0.10#53
Name:	clickhouse-clickhouse.flow-visibility.svc.cluster.local
Address: 10.96.87.197


clickhouse-clickhouse.flow-visibility.svc.cluster.local
Server:		10.96.0.10
Address:	10.96.0.10#53
Name:	clickhouse-clickhouse.flow-visibility.svc.cluster.local
Address: 10.96.87.197

clickhouse-clickhouse.flow-visibility.svc.cluster.local
Server:		10.96.0.10
Address:	10.96.0.10#53
** server can't find clickhouse-clickhouse.flow-visibility.svc.cluster.local: NXDOMAIN

clickhouse-clickhouse.flow-visibility.svc.cluster.local
Server:		10.96.0.10
Address:	10.96.0.10#53
Name:	clickhouse-clickhouse.flow-visibility.svc.cluster.local
Address: 10.96.87.197
