### PR TITLE
Remove android library in action to save space storage for e2e test.

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -114,6 +114,7 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf "/usr/local/lib/android"
           df -h
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -180,6 +181,7 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf "/usr/local/lib/android"
           df -h
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4


### PR DESCRIPTION
Add `sudo rm -rf "/usr/local/lib/android"` to release ~10GB space for e2e test.

before
<img width="500" alt="image" src="https://user-images.githubusercontent.com/59460118/232640041-ab327a88-0d17-42d9-bad6-a6a3c5405c52.png">

after
<img width="500" alt="image" src="https://user-images.githubusercontent.com/59460118/232639817-6136e747-c95e-4d28-80ae-f5682e90f07a.png">
