### PR TITLE
Reduce Docker images vulnerabilities

### DIFF
--- a/build/images/Dockerfile.spark-jobs.ubuntu
+++ b/build/images/Dockerfile.spark-jobs.ubuntu
@@ -1,4 +1,4 @@
-FROM apache/spark-py:v3.3.2
+FROM apache/spark-py:v3.4.0
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A docker image to deploy policy recommendation and throughput anomaly detection Spark job."

--- a/build/images/Dockerfile.theia-manager.ubuntu
+++ b/build/images/Dockerfile.theia-manager.ubuntu
@@ -7,7 +7,7 @@ WORKDIR /theia
 RUN make theia-manager-bin
 
 # Chose this base image so that a shell is available for users to exec into the container
-FROM ubuntu:20.04
+FROM ubuntu:23.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A docker image to deploy theia manager."


### PR DESCRIPTION
Trivy_scan is producing a lot of critical vulnerabilities which could be resolved by updating the old base images for the dockerfiles.