### PR TITLE
Python Coverage

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -117,6 +117,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: python-coverage
 
   check-udf-changes:
     name: Check whether udf tests need to be run based on diff


### PR DESCRIPTION
Adds python coverage to codecov. Infrastructure already exists, changes made allow coverage information to be viewed on codecov website and PR comments.

Fixes issue #285