### PR TITLE
Upgrade ClickHouse server image to v23.4

### DIFF
--- a/build/charts/theia/crds/clickhouse-operator-install-bundle.yaml
+++ b/build/charts/theia/crds/clickhouse-operator-install-bundle.yaml
@@ -10,7 +10,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
   labels:
-    clickhouse.altinity.com/chop: 0.18.2
+    clickhouse.altinity.com/chop: 0.21.0
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
@@ -33,7 +33,6 @@ spec:
         - name: clusters
           type: integer
           description: Clusters count
-          priority: 0 # show in standard view
           jsonPath: .status.clusters
         - name: shards
           type: integer
@@ -43,7 +42,6 @@ spec:
         - name: hosts
           type: integer
           description: Hosts count
-          priority: 0 # show in standard view
           jsonPath: .status.hosts
         - name: taskID
           type: string
@@ -53,33 +51,41 @@ spec:
         - name: status
           type: string
           description: CHI status
-          priority: 0 # show in standard view
           jsonPath: .status.status
-        - name: updated
+        - name: hosts-updated
           type: integer
           description: Updated hosts count
           priority: 1 # show in wide view
-          jsonPath: .status.updated
-        - name: added
+          jsonPath: .status.hostsUpdated
+        - name: hosts-added
           type: integer
           description: Added hosts count
           priority: 1 # show in wide view
-          jsonPath: .status.added
-        - name: deleted
+          jsonPath: .status.hostsAdded
+        - name: hosts-completed
+          type: integer
+          description: Completed hosts count
+          jsonPath: .status.hostsCompleted
+        - name: hosts-deleted
           type: integer
           description: Hosts deleted count
           priority: 1 # show in wide view
-          jsonPath: .status.deleted
-        - name: delete
+          jsonPath: .status.hostsDeleted
+        - name: hosts-delete
           type: integer
           description: Hosts to be deleted count
           priority: 1 # show in wide view
-          jsonPath: .status.delete
+          jsonPath: .status.hostsDelete
         - name: endpoint
           type: string
           description: Client access endpoint
           priority: 1 # show in wide view
           jsonPath: .status.endpoint
+        - name: age
+          type: date
+          description: Age of the resource
+          # Displayed in all priorities
+          jsonPath: .metadata.creationTimestamp
       subresources:
         status: {}
       schema:
@@ -114,6 +120,9 @@ spec:
                 chop-date:
                   type: string
                   description: "ClickHouse operator build date"
+                chop-ip:
+                  type: string
+                  description: "IP address of the operator's pod which managed this CHI"
                 clusters:
                   type: integer
                   minimum: 0
@@ -162,25 +171,34 @@ spec:
                   description: "Errors"
                   items:
                     type: string
-                updated:
+                hostsUpdated:
                   type: integer
                   minimum: 0
                   description: "Updated Hosts count"
-                added:
+                hostsAdded:
                   type: integer
                   minimum: 0
                   description: "Added Hosts count"
-                deleted:
+                hostsCompleted:
+                  type: integer
+                  minimum: 0
+                  description: "Completed Hosts count"
+                hostsDeleted:
                   type: integer
                   minimum: 0
                   description: "Deleted Hosts count"
-                delete:
+                hostsDelete:
                   type: integer
                   minimum: 0
                   description: "About to delete Hosts count"
                 pods:
                   type: array
                   description: "Pods"
+                  items:
+                    type: string
+                pod-ips:
+                  type: array
+                  description: "Pod IPs"
                   items:
                     type: string
                 fqdns:
@@ -197,20 +215,30 @@ spec:
                   description: "Generation"
                 normalized:
                   type: object
-                  description: "Normalized CHI"
+                  description: "Normalized CHI requested"
                   x-kubernetes-preserve-unknown-fields: true
+                normalizedCompleted:
+                  type: object
+                  description: "Normalized CHI completed"
+                  x-kubernetes-preserve-unknown-fields: true
+                hostsWithTablesCreated:
+                  type: array
+                  description: "List of hosts with tables created by the operator"
+                  items:
+                    type: string
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
               description: |
                 Specification of the desired behavior of one or more ClickHouse clusters
-                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md
               properties:
                 taskID:
                   type: string
-                  description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
-                # Need to be StringBool
-                stop:
+                  description: |
+                    Allows to define custom taskID for named update operation and watch status of this update execution in .status.taskIDs field.
+                    By default every update of chi manifest will generate random taskID
+                stop: &TypeStringBool
                   type: string
                   description: |
                     Allow stop all ClickHouse clusters described in current chi.
@@ -248,35 +276,9 @@ spec:
                   enum:
                     - ""
                     - "RollingUpdate"
-                # Need to be StringBool
                 troubleshoot:
-                  type: string
+                  <<: *TypeStringBool
                   description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
-                  enum:
-                    # List StringBoolXXX constants from model
-                    - ""
-                    - "0"
-                    - "1"
-                    - "False"
-                    - "false"
-                    - "True"
-                    - "true"
-                    - "No"
-                    - "no"
-                    - "Yes"
-                    - "yes"
-                    - "Off"
-                    - "off"
-                    - "On"
-                    - "on"
-                    - "Disable"
-                    - "disable"
-                    - "Enable"
-                    - "enable"
-                    - "Disabled"
-                    - "disabled"
-                    - "Enabled"
-                    - "enabled"
                 namespaceDomainPattern:
                   type: string
                   description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
@@ -316,7 +318,7 @@ spec:
                           description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
                           # nullable: true
                           properties:
-                            statefulSet:
+                            statefulSet: &TypeObjectsCleanup
                               type: string
                               description: "behavior policy for unknown StatefulSet, Delete by default"
                               enum:
@@ -325,58 +327,31 @@ spec:
                                 - "Delete"
                             pvc:
                               type: string
+                              <<: *TypeObjectsCleanup
                               description: "behavior policy for unknown PVC, Delete by default"
-                              enum:
-                                # List ObjectsCleanupXXX constants from model
-                                - "Retain"
-                                - "Delete"
                             configMap:
-                              type: string
+                              <<: *TypeObjectsCleanup
                               description: "behavior policy for unknown ConfigMap, Delete by default"
-                              enum:
-                                # List ObjectsCleanupXXX constants from model
-                                - "Retain"
-                                - "Delete"
                             service:
-                              type: string
+                              <<: *TypeObjectsCleanup
                               description: "behavior policy for unknown Service, Delete by default"
-                              enum:
-                                # List ObjectsCleanupXXX constants from model
-                                - "Retain"
-                                - "Delete"
                         reconcileFailedObjects:
                           type: object
                           description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
                           # nullable: true
                           properties:
                             statefulSet:
-                              type: string
+                              <<: *TypeObjectsCleanup
                               description: "behavior policy for failed StatefulSet reconciling, Retain by default"
-                              enum:
-                                # List ObjectsCleanupXXX constants from model
-                                - "Retain"
-                                - "Delete"
                             pvc:
-                              type: string
+                              <<: *TypeObjectsCleanup
                               description: "behavior policy for failed PVC reconciling, Retain by default"
-                              enum:
-                                # List ObjectsCleanupXXX constants from model
-                                - "Retain"
-                                - "Delete"
                             configMap:
-                              type: string
+                              <<: *TypeObjectsCleanup
                               description: "behavior policy for failed ConfigMap reconciling, Retain by default"
-                              enum:
-                                # List ObjectsCleanupXXX constants from model
-                                - "Retain"
-                                - "Delete"
                             service:
-                              type: string
+                              <<: *TypeObjectsCleanup
                               description: "behavior policy for failed Service reconciling, Retain by default"
-                              enum:
-                                # List ObjectsCleanupXXX constants from model
-                                - "Retain"
-                                - "Delete"
                 defaults:
                   type: object
                   description: |
@@ -384,37 +359,12 @@ spec:
                     More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
                   # nullable: true
                   properties:
-                    # Need to be StringBool
                     replicasUseFQDN:
-                      type: string
+                      <<: *TypeStringBool
                       description: |
-                        define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                        define should replicas be specified by FQDN in `<host></host>`.
+                        In case of "no" will use short hostname and clickhouse-server will use kubernetes default suffixes for DNS lookup
                         "yes" by default
-                      enum:
-                        # List StringBoolXXX constants from model
-                        - ""
-                        - "0"
-                        - "1"
-                        - "False"
-                        - "false"
-                        - "True"
-                        - "true"
-                        - "No"
-                        - "no"
-                        - "Yes"
-                        - "yes"
-                        - "Off"
-                        - "off"
-                        - "On"
-                        - "on"
-                        - "Disable"
-                        - "disable"
-                        - "Enable"
-                        - "enable"
-                        - "Disabled"
-                        - "disabled"
-                        - "Enabled"
-                        - "enabled"
                     distributedDDL:
                       type: object
                       description: |
@@ -425,7 +375,27 @@ spec:
                         profile:
                           type: string
                           description: "Settings from this profile will be used to execute DDL queries"
-                    templates:
+                    storageManagement:
+                      type: object
+                      description: default storage management options
+                      properties:
+                        provisioner: &TypePVCProvisioner
+                          type: string
+                          description: "defines `PVC` provisioner - be it StatefulSet or the Operator"
+                          enum:
+                            - ""
+                            - "StatefulSet"
+                            - "Operator"
+                        reclaimPolicy: &TypePVCReclaimPolicy
+                          type: string
+                          description: |
+                            defines behavior of `PVC` deletion.
+                            `Delete` by default, if `Retain` specified then `PVC` will be kept when deleting StatefulSet
+                          enum:
+                            - ""
+                            - "Retain"
+                            - "Delete"
+                    templates: &TypeTemplateNames
                       type: object
                       description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
                       # nullable: true
@@ -462,7 +432,7 @@ spec:
                   description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
                   # nullable: true
                   properties:
-                    zookeeper:
+                    zookeeper: &TypeZookeeperConfig
                       type: object
                       description: |
                         allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
@@ -488,6 +458,9 @@ spec:
                                 description: "TCP port which used to connect to Zookeeper node"
                                 minimum: 0
                                 maximum: 65535
+                              secure:
+                                <<: *TypeStringBool
+                                description: "if a secure connection to Zookeeper is required"
                         session_timeout_ms:
                           type: integer
                           description: "session timeout during connect to Zookeeper"
@@ -527,7 +500,7 @@ spec:
                         Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
                       # nullable: true
                       x-kubernetes-preserve-unknown-fields: true
-                    settings:
+                    settings: &TypeSettings
                       type: object
                       description: |
                         allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
@@ -535,7 +508,7 @@ spec:
                         Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
                       # nullable: true
                       x-kubernetes-preserve-unknown-fields: true
-                    files:
+                    files: &TypeFiles
                       type: object
                       description: |
                         allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
@@ -568,90 +541,86 @@ spec:
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           zookeeper:
-                            type: object
+                            <<: *TypeZookeeperConfig
                             description: |
                               optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
                               override top-level `chi.spec.configuration.zookeeper` settings
-                            # nullable: true
-                            properties:
-                              nodes:
-                                type: array
-                                description: "describe every available zookeeper cluster node for interaction"
-                                # nullable: true
-                                items:
-                                  type: object
-                                  #required:
-                                  #  - host
-                                  properties:
-                                    host:
-                                      type: string
-                                      description: "dns name or ip address for Zookeeper node"
-                                    port:
-                                      type: integer
-                                      description: "TCP port which used to connect to Zookeeper node"
-                                      minimum: 0
-                                      maximum: 65535
-                              session_timeout_ms:
-                                type: integer
-                                description: "session timeout during connect to Zookeeper"
-                              operation_timeout_ms:
-                                type: integer
-                                description: "one operation timeout during Zookeeper transactions"
-                              root:
-                                type: string
-                                description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
-                              identity:
-                                type: string
-                                description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                           settings:
-                            type: object
+                            <<: *TypeSettings
                             description: |
                               optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
                               override top-level `chi.spec.configuration.settings`
                               More details: https://clickhouse.tech/docs/en/operations/settings/settings/
-                            # nullable: true
-                            x-kubernetes-preserve-unknown-fields: true
                           files:
-                            type: object
+                            <<: *TypeFiles
                             description: |
                               optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
                               override top-level `chi.spec.configuration.files`
-                            # nullable: true
-                            x-kubernetes-preserve-unknown-fields: true
                           templates:
-                            type: object
+                            <<: *TypeTemplateNames
                             description: |
                               optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
                               override top-level `chi.spec.configuration.templates`
-                            # nullable: true
+                          schemaPolicy:
+                            type: object
+                            description: |
+                              describes how schema is propagated within replicas and shards
                             properties:
-                              hostTemplate:
+                              replica:
                                 type: string
-                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
-                              podTemplate:
+                                description: "how schema is propagated within a replica"
+                                enum:
+                                  # List SchemaPolicyReplicaXXX constants from model
+                                  - "None"
+                                  - "All"
+                              shard:
                                 type: string
-                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
-                              dataVolumeClaimTemplate:
+                                description: "how schema is propagated between shards"
+                                enum:
+                                  # List SchemaPolicyShardXXX constants from model
+                                  - "None"
+                                  - "All"
+                                  - "DistributedTablesOnly"
+                          insecure:
+                            <<: *TypeStringBool
+                            description: optional, open insecure ports for cluster, defaults to "yes"
+                          secure:
+                            <<: *TypeStringBool
+                            description: optional, open secure ports for cluster
+                          secret:
+                            type: object
+                            description: "optional, shared secret value to secure cluster communications"
+                            properties:
+                              auto:
+                                <<: *TypeStringBool
+                                description: "Auto-generate shared secret value to secure cluster communications"
+                              value:
+                                description: "Cluster shared secret value in plain text"
                                 type: string
-                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
-                              logVolumeClaimTemplate:
-                                type: string
-                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
-                              serviceTemplate:
-                                type: string
-                                description: "optional, fully ignores for cluster-level"
-                              clusterServiceTemplate:
-                                type: string
-                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
-                              shardServiceTemplate:
-                                type: string
-                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
-                              replicaServiceTemplate:
-                                type: string
-                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
-                              volumeClaimTemplate:
-                                type: string
-                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                              valueFrom:
+                                description: "Cluster shared secret source"
+                                type: object
+                                properties:
+                                  secretKeyRef:
+                                    description: |
+                                      Selects a key of a secret in the clickhouse installation namespace.
+                                      Should not be used if value is not empty.
+                                    type: object
+                                    properties:
+                                      name:
+                                        description: |
+                                          Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      key:
+                                        description: The key of the secret to select from. Must be a valid secret key.
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                      - name
+                                      - key
                           layout:
                             type: object
                             description: |
@@ -682,7 +651,6 @@ spec:
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
-
                                     definitionType:
                                       type: string
                                       description: "DEPRECATED - to be removed soon"
@@ -692,88 +660,29 @@ spec:
                                         optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
                                         will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
                                         More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
-                                    # Need to be StringBool
                                     internalReplication:
-                                      type: string
+                                      <<: *TypeStringBool
                                       description: |
                                         optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
                                         allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
                                         will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
                                         More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
-                                      enum:
-                                        # List StringBoolXXX constants from model
-                                        - ""
-                                        - "0"
-                                        - "1"
-                                        - "False"
-                                        - "false"
-                                        - "True"
-                                        - "true"
-                                        - "No"
-                                        - "no"
-                                        - "Yes"
-                                        - "yes"
-                                        - "Off"
-                                        - "off"
-                                        - "On"
-                                        - "on"
-                                        - "Disable"
-                                        - "disable"
-                                        - "Enable"
-                                        - "enable"
-                                        - "Disabled"
-                                        - "disabled"
-                                        - "Enabled"
-                                        - "enabled"
                                     settings:
-                                      type: object
-                                      # nullable: true
+                                      <<: *TypeSettings
                                       description: |
                                         optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
                                         override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
                                         More details: https://clickhouse.tech/docs/en/operations/settings/settings/
-                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
-                                      type: object
-                                      # nullable: true
+                                      <<: *TypeFiles
                                       description: |
                                         optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
                                         override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
-                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
-                                      type: object
+                                      <<: *TypeTemplateNames
                                       description: |
                                         optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
                                         override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
-                                      # nullable: true
-                                      properties:
-                                        hostTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
-                                        podTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                        dataVolumeClaimTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                        logVolumeClaimTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                        serviceTemplate:
-                                          type: string
-                                          description: "optional, fully ignores for shard-level"
-                                        clusterServiceTemplate:
-                                          type: string
-                                          description: "optional, fully ignores for shard-level"
-                                        shardServiceTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
-                                        replicaServiceTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
-                                        volumeClaimTemplate:
-                                          type: string
-                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     replicasCount:
                                       type: integer
                                       description: |
@@ -797,6 +706,14 @@ spec:
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          insecure:
+                                            <<: *TypeStringBool
+                                            description: |
+                                              optional, open insecure ports for cluster, defaults to "yes"
+                                          secure:
+                                            <<: *TypeStringBool
+                                            description: |
+                                              optional, open secure ports
                                           tcpPort:
                                             type: integer
                                             description: |
@@ -804,11 +721,19 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          tlsPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
                                           httpPort:
                                             type: integer
                                             description: |
                                               optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
                                               allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpsPort:
+                                            type: integer
                                             minimum: 1
                                             maximum: 65535
                                           interserverHTTPPort:
@@ -819,54 +744,21 @@ spec:
                                             minimum: 1
                                             maximum: 65535
                                           settings:
-                                            type: object
-                                            # nullable: true
+                                            <<: *TypeSettings
                                             description: |
                                               optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
                                               override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
                                               More details: https://clickhouse.tech/docs/en/operations/settings/settings/
-                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
-                                            type: object
-                                            # nullable: true
+                                            <<: *TypeFiles
                                             description: |
                                               optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
                                               override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
-                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
-                                            type: object
+                                            <<: *TypeTemplateNames
                                             description: |
                                               optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
                                               override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
-                                            # nullable: true
-                                            properties:
-                                              hostTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
-                                              podTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
-                                              dataVolumeClaimTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                              logVolumeClaimTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                              serviceTemplate:
-                                                type: string
-                                                description: "optional, fully ignores for replica-level"
-                                              clusterServiceTemplate:
-                                                type: string
-                                                description: "optional, fully ignores for replica-level"
-                                              shardServiceTemplate:
-                                                type: string
-                                                description: "optional, fully ignores for replica-level"
-                                              replicaServiceTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
-                                              volumeClaimTemplate:
-                                                type: string
-                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                               replicas:
                                 type: array
                                 description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
@@ -882,54 +774,21 @@ spec:
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
                                     settings:
-                                      type: object
+                                      <<: *TypeSettings
                                       description: |
                                         optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
                                         override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
                                         More details: https://clickhouse.tech/docs/en/operations/settings/settings/
-                                      # nullable: true
-                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
-                                      type: object
-                                      # nullable: true
+                                      <<: *TypeFiles
                                       description: |
                                         optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
                                         override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
-                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
-                                      type: object
+                                      <<: *TypeTemplateNames
                                       description: |
                                         optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
                                         override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
-                                      # nullable: true
-                                      properties:
-                                        hostTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
-                                        podTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
-                                        dataVolumeClaimTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                        logVolumeClaimTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                        serviceTemplate:
-                                          type: string
-                                          description: "optional, fully ignores for replica-level"
-                                        clusterServiceTemplate:
-                                          type: string
-                                          description: "optional, fully ignores for replica-level"
-                                        shardServiceTemplate:
-                                          type: string
-                                          description: "optional, fully ignores for replica-level"
-                                        replicaServiceTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
-                                        volumeClaimTemplate:
-                                          type: string
-                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     shardsCount:
                                       type: integer
                                       description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
@@ -949,6 +808,14 @@ spec:
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          insecure:
+                                            <<: *TypeStringBool
+                                            description: |
+                                              optional, open insecure ports for cluster, defaults to "yes"
+                                          secure:
+                                            <<: *TypeStringBool
+                                            description: |
+                                              optional, open secure ports
                                           tcpPort:
                                             type: integer
                                             description: |
@@ -956,11 +823,19 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          tlsPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
                                           httpPort:
                                             type: integer
                                             description: |
                                               optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
                                               allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpsPort:
+                                            type: integer
                                             minimum: 1
                                             maximum: 65535
                                           interserverHTTPPort:
@@ -971,54 +846,21 @@ spec:
                                             minimum: 1
                                             maximum: 65535
                                           settings:
-                                            type: object
+                                            <<: *TypeSettings
                                             description: |
                                               optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
                                               override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
                                               More details: https://clickhouse.tech/docs/en/operations/settings/settings/
-                                            # nullable: true
-                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
-                                            type: object
+                                            <<: *TypeFiles
                                             description: |
                                               optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
                                               override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
-                                            # nullable: true
-                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
-                                            type: object
+                                            <<: *TypeTemplateNames
                                             description: |
                                               optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
                                               override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
-                                            # nullable: true
-                                            properties:
-                                              hostTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
-                                              podTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                              dataVolumeClaimTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                              logVolumeClaimTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                              serviceTemplate:
-                                                type: string
-                                                description: "optional, fully ignores for shard-level"
-                                              clusterServiceTemplate:
-                                                type: string
-                                                description: "optional, fully ignores for shard-level"
-                                              shardServiceTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
-                                              replicaServiceTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
-                                              volumeClaimTemplate:
-                                                type: string
-                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 templates:
                   type: object
                   description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
@@ -1064,6 +906,14 @@ spec:
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
                                 pattern: "^[a-zA-Z0-9-]{0,15}$"
+                              insecure:
+                                <<: *TypeStringBool
+                                description: |
+                                  optional, open insecure ports for cluster, defaults to "yes"
+                              secure:
+                                <<: *TypeStringBool
+                                description: |
+                                  optional, open secure ports
                               tcpPort:
                                 type: integer
                                 description: |
@@ -1072,12 +922,20 @@ spec:
                                   More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
+                              tlsPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
                               httpPort:
                                 type: integer
                                 description: |
                                   optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
                                   if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
                                   More info: https://clickhouse.tech/docs/en/interfaces/http/
+                                minimum: 1
+                                maximum: 65535
+                              httpsPort:
+                                type: integer
                                 minimum: 1
                                 maximum: 65535
                               interserverHTTPPort:
@@ -1089,39 +947,17 @@ spec:
                                 minimum: 1
                                 maximum: 65535
                               settings:
-                                type: object
+                                <<: *TypeSettings
                                 description: |
                                   optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
                                   More details: https://clickhouse.tech/docs/en/operations/settings/settings/
-                                # nullable: true
-                                x-kubernetes-preserve-unknown-fields: true
                               files:
-                                type: object
+                                <<: *TypeFiles
                                 description: |
                                   optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
-                                # nullable: true
-                                x-kubernetes-preserve-unknown-fields: true
                               templates:
-                                type: object
+                                <<: *TypeTemplateNames
                                 description: "be careful, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
-                                # nullable: true
-                                properties:
-                                  hostTemplate:
-                                    type: string
-                                  podTemplate:
-                                    type: string
-                                  dataVolumeClaimTemplate:
-                                    type: string
-                                  logVolumeClaimTemplate:
-                                    type: string
-                                  serviceTemplate:
-                                    type: string
-                                  clusterServiceTemplate:
-                                    type: string
-                                  shardServiceTemplate:
-                                    type: string
-                                  replicaServiceTemplate:
-                                    type: string
 
                     podTemplates:
                       type: array
@@ -1164,7 +1000,7 @@ spec:
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            description: "define ClickHouse Pod distribution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
                             # nullable: true
                             items:
                               type: object
@@ -1237,24 +1073,19 @@ spec:
                         #  - spec
                         properties:
                           name:
+                            type: string
                             description: |
                               template name, could use to link inside
                               top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
                               cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
                               shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
                               replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
-                            type: string
-                          reclaimPolicy:
-                            type: string
-                            description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
-                            enum:
-                              - ""
-                              - "Retain"
-                              - "Delete"
+                          provisioner: *TypePVCProvisioner
+                          reclaimPolicy: *TypePVCReclaimPolicy
                           metadata:
                             type: object
                             description: |
-                              allows pass standard object's metadata from template to PVC
+                              allows to pass standard object's metadata from template to PVC
                               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                             # nullable: true
                             x-kubernetes-preserve-unknown-fields: true
@@ -1339,7 +1170,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
   labels:
-    clickhouse.altinity.com/chop: 0.18.2
+    clickhouse.altinity.com/chop: 0.21.0
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
@@ -1362,7 +1193,6 @@ spec:
         - name: clusters
           type: integer
           description: Clusters count
-          priority: 0 # show in standard view
           jsonPath: .status.clusters
         - name: shards
           type: integer
@@ -1372,7 +1202,6 @@ spec:
         - name: hosts
           type: integer
           description: Hosts count
-          priority: 0 # show in standard view
           jsonPath: .status.hosts
         - name: taskID
           type: string
@@ -1382,33 +1211,41 @@ spec:
         - name: status
           type: string
           description: CHI status
-          priority: 0 # show in standard view
           jsonPath: .status.status
-        - name: updated
+        - name: hosts-updated
           type: integer
           description: Updated hosts count
           priority: 1 # show in wide view
-          jsonPath: .status.updated
-        - name: added
+          jsonPath: .status.hostsUpdated
+        - name: hosts-added
           type: integer
           description: Added hosts count
           priority: 1 # show in wide view
-          jsonPath: .status.added
-        - name: deleted
+          jsonPath: .status.hostsAdded
+        - name: hosts-completed
+          type: integer
+          description: Completed hosts count
+          jsonPath: .status.hostsCompleted
+        - name: hosts-deleted
           type: integer
           description: Hosts deleted count
           priority: 1 # show in wide view
-          jsonPath: .status.deleted
-        - name: delete
+          jsonPath: .status.hostsDeleted
+        - name: hosts-delete
           type: integer
           description: Hosts to be deleted count
           priority: 1 # show in wide view
-          jsonPath: .status.delete
+          jsonPath: .status.hostsDelete
         - name: endpoint
           type: string
           description: Client access endpoint
           priority: 1 # show in wide view
           jsonPath: .status.endpoint
+        - name: age
+          type: date
+          description: Age of the resource
+          # Displayed in all priorities
+          jsonPath: .metadata.creationTimestamp
       subresources:
         status: {}
       schema:
@@ -1443,6 +1280,9 @@ spec:
                 chop-date:
                   type: string
                   description: "ClickHouse operator build date"
+                chop-ip:
+                  type: string
+                  description: "IP address of the operator's pod which managed this CHI"
                 clusters:
                   type: integer
                   minimum: 0
@@ -1491,25 +1331,34 @@ spec:
                   description: "Errors"
                   items:
                     type: string
-                updated:
+                hostsUpdated:
                   type: integer
                   minimum: 0
                   description: "Updated Hosts count"
-                added:
+                hostsAdded:
                   type: integer
                   minimum: 0
                   description: "Added Hosts count"
-                deleted:
+                hostsCompleted:
+                  type: integer
+                  minimum: 0
+                  description: "Completed Hosts count"
+                hostsDeleted:
                   type: integer
                   minimum: 0
                   description: "Deleted Hosts count"
-                delete:
+                hostsDelete:
                   type: integer
                   minimum: 0
                   description: "About to delete Hosts count"
                 pods:
                   type: array
                   description: "Pods"
+                  items:
+                    type: string
+                pod-ips:
+                  type: array
+                  description: "Pod IPs"
                   items:
                     type: string
                 fqdns:
@@ -1526,20 +1375,30 @@ spec:
                   description: "Generation"
                 normalized:
                   type: object
-                  description: "Normalized CHI"
+                  description: "Normalized CHI requested"
                   x-kubernetes-preserve-unknown-fields: true
+                normalizedCompleted:
+                  type: object
+                  description: "Normalized CHI completed"
+                  x-kubernetes-preserve-unknown-fields: true
+                hostsWithTablesCreated:
+                  type: array
+                  description: "List of hosts with tables created by the operator"
+                  items:
+                    type: string
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
               description: |
                 Specification of the desired behavior of one or more ClickHouse clusters
-                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md
               properties:
                 taskID:
                   type: string
-                  description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
-                # Need to be StringBool
-                stop:
+                  description: |
+                    Allows to define custom taskID for named update operation and watch status of this update execution in .status.taskIDs field.
+                    By default every update of chi manifest will generate random taskID
+                stop: &TypeStringBool
                   type: string
                   description: |
                     Allow stop all ClickHouse clusters described in current chi.
@@ -1577,35 +1436,9 @@ spec:
                   enum:
                     - ""
                     - "RollingUpdate"
-                # Need to be StringBool
                 troubleshoot:
-                  type: string
+                  <<: *TypeStringBool
                   description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
-                  enum:
-                    # List StringBoolXXX constants from model
-                    - ""
-                    - "0"
-                    - "1"
-                    - "False"
-                    - "false"
-                    - "True"
-                    - "true"
-                    - "No"
-                    - "no"
-                    - "Yes"
-                    - "yes"
-                    - "Off"
-                    - "off"
-                    - "On"
-                    - "on"
-                    - "Disable"
-                    - "disable"
-                    - "Enable"
-                    - "enable"
-                    - "Disabled"
-                    - "disabled"
-                    - "Enabled"
-                    - "enabled"
                 namespaceDomainPattern:
                   type: string
                   description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
@@ -1645,7 +1478,7 @@ spec:
                           description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
                           # nullable: true
                           properties:
-                            statefulSet:
+                            statefulSet: &TypeObjectsCleanup
                               type: string
                               description: "behavior policy for unknown StatefulSet, Delete by default"
                               enum:
@@ -1654,58 +1487,31 @@ spec:
                                 - "Delete"
                             pvc:
                               type: string
+                              <<: *TypeObjectsCleanup
                               description: "behavior policy for unknown PVC, Delete by default"
-                              enum:
-                                # List ObjectsCleanupXXX constants from model
-                                - "Retain"
-                                - "Delete"
                             configMap:
-                              type: string
+                              <<: *TypeObjectsCleanup
                               description: "behavior policy for unknown ConfigMap, Delete by default"
-                              enum:
-                                # List ObjectsCleanupXXX constants from model
-                                - "Retain"
-                                - "Delete"
                             service:
-                              type: string
+                              <<: *TypeObjectsCleanup
                               description: "behavior policy for unknown Service, Delete by default"
-                              enum:
-                                # List ObjectsCleanupXXX constants from model
-                                - "Retain"
-                                - "Delete"
                         reconcileFailedObjects:
                           type: object
                           description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
                           # nullable: true
                           properties:
                             statefulSet:
-                              type: string
+                              <<: *TypeObjectsCleanup
                               description: "behavior policy for failed StatefulSet reconciling, Retain by default"
-                              enum:
-                                # List ObjectsCleanupXXX constants from model
-                                - "Retain"
-                                - "Delete"
                             pvc:
-                              type: string
+                              <<: *TypeObjectsCleanup
                               description: "behavior policy for failed PVC reconciling, Retain by default"
-                              enum:
-                                # List ObjectsCleanupXXX constants from model
-                                - "Retain"
-                                - "Delete"
                             configMap:
-                              type: string
+                              <<: *TypeObjectsCleanup
                               description: "behavior policy for failed ConfigMap reconciling, Retain by default"
-                              enum:
-                                # List ObjectsCleanupXXX constants from model
-                                - "Retain"
-                                - "Delete"
                             service:
-                              type: string
+                              <<: *TypeObjectsCleanup
                               description: "behavior policy for failed Service reconciling, Retain by default"
-                              enum:
-                                # List ObjectsCleanupXXX constants from model
-                                - "Retain"
-                                - "Delete"
                 defaults:
                   type: object
                   description: |
@@ -1713,37 +1519,12 @@ spec:
                     More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
                   # nullable: true
                   properties:
-                    # Need to be StringBool
                     replicasUseFQDN:
-                      type: string
+                      <<: *TypeStringBool
                       description: |
-                        define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                        define should replicas be specified by FQDN in `<host></host>`.
+                        In case of "no" will use short hostname and clickhouse-server will use kubernetes default suffixes for DNS lookup
                         "yes" by default
-                      enum:
-                        # List StringBoolXXX constants from model
-                        - ""
-                        - "0"
-                        - "1"
-                        - "False"
-                        - "false"
-                        - "True"
-                        - "true"
-                        - "No"
-                        - "no"
-                        - "Yes"
-                        - "yes"
-                        - "Off"
-                        - "off"
-                        - "On"
-                        - "on"
-                        - "Disable"
-                        - "disable"
-                        - "Enable"
-                        - "enable"
-                        - "Disabled"
-                        - "disabled"
-                        - "Enabled"
-                        - "enabled"
                     distributedDDL:
                       type: object
                       description: |
@@ -1754,7 +1535,27 @@ spec:
                         profile:
                           type: string
                           description: "Settings from this profile will be used to execute DDL queries"
-                    templates:
+                    storageManagement:
+                      type: object
+                      description: default storage management options
+                      properties:
+                        provisioner: &TypePVCProvisioner
+                          type: string
+                          description: "defines `PVC` provisioner - be it StatefulSet or the Operator"
+                          enum:
+                            - ""
+                            - "StatefulSet"
+                            - "Operator"
+                        reclaimPolicy: &TypePVCReclaimPolicy
+                          type: string
+                          description: |
+                            defines behavior of `PVC` deletion.
+                            `Delete` by default, if `Retain` specified then `PVC` will be kept when deleting StatefulSet
+                          enum:
+                            - ""
+                            - "Retain"
+                            - "Delete"
+                    templates: &TypeTemplateNames
                       type: object
                       description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
                       # nullable: true
@@ -1791,7 +1592,7 @@ spec:
                   description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
                   # nullable: true
                   properties:
-                    zookeeper:
+                    zookeeper: &TypeZookeeperConfig
                       type: object
                       description: |
                         allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
@@ -1817,6 +1618,9 @@ spec:
                                 description: "TCP port which used to connect to Zookeeper node"
                                 minimum: 0
                                 maximum: 65535
+                              secure:
+                                <<: *TypeStringBool
+                                description: "if a secure connection to Zookeeper is required"
                         session_timeout_ms:
                           type: integer
                           description: "session timeout during connect to Zookeeper"
@@ -1856,7 +1660,7 @@ spec:
                         Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
                       # nullable: true
                       x-kubernetes-preserve-unknown-fields: true
-                    settings:
+                    settings: &TypeSettings
                       type: object
                       description: |
                         allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
@@ -1864,7 +1668,7 @@ spec:
                         Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
                       # nullable: true
                       x-kubernetes-preserve-unknown-fields: true
-                    files:
+                    files: &TypeFiles
                       type: object
                       description: |
                         allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
@@ -1897,90 +1701,86 @@ spec:
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           zookeeper:
-                            type: object
+                            <<: *TypeZookeeperConfig
                             description: |
                               optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
                               override top-level `chi.spec.configuration.zookeeper` settings
-                            # nullable: true
-                            properties:
-                              nodes:
-                                type: array
-                                description: "describe every available zookeeper cluster node for interaction"
-                                # nullable: true
-                                items:
-                                  type: object
-                                  #required:
-                                  #  - host
-                                  properties:
-                                    host:
-                                      type: string
-                                      description: "dns name or ip address for Zookeeper node"
-                                    port:
-                                      type: integer
-                                      description: "TCP port which used to connect to Zookeeper node"
-                                      minimum: 0
-                                      maximum: 65535
-                              session_timeout_ms:
-                                type: integer
-                                description: "session timeout during connect to Zookeeper"
-                              operation_timeout_ms:
-                                type: integer
-                                description: "one operation timeout during Zookeeper transactions"
-                              root:
-                                type: string
-                                description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
-                              identity:
-                                type: string
-                                description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                           settings:
-                            type: object
+                            <<: *TypeSettings
                             description: |
                               optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
                               override top-level `chi.spec.configuration.settings`
                               More details: https://clickhouse.tech/docs/en/operations/settings/settings/
-                            # nullable: true
-                            x-kubernetes-preserve-unknown-fields: true
                           files:
-                            type: object
+                            <<: *TypeFiles
                             description: |
                               optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
                               override top-level `chi.spec.configuration.files`
-                            # nullable: true
-                            x-kubernetes-preserve-unknown-fields: true
                           templates:
-                            type: object
+                            <<: *TypeTemplateNames
                             description: |
                               optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
                               override top-level `chi.spec.configuration.templates`
-                            # nullable: true
+                          schemaPolicy:
+                            type: object
+                            description: |
+                              describes how schema is propagated within replicas and shards
                             properties:
-                              hostTemplate:
+                              replica:
                                 type: string
-                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
-                              podTemplate:
+                                description: "how schema is propagated within a replica"
+                                enum:
+                                  # List SchemaPolicyReplicaXXX constants from model
+                                  - "None"
+                                  - "All"
+                              shard:
                                 type: string
-                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
-                              dataVolumeClaimTemplate:
+                                description: "how schema is propagated between shards"
+                                enum:
+                                  # List SchemaPolicyShardXXX constants from model
+                                  - "None"
+                                  - "All"
+                                  - "DistributedTablesOnly"
+                          insecure:
+                            <<: *TypeStringBool
+                            description: optional, open insecure ports for cluster, defaults to "yes"
+                          secure:
+                            <<: *TypeStringBool
+                            description: optional, open secure ports for cluster
+                          secret:
+                            type: object
+                            description: "optional, shared secret value to secure cluster communications"
+                            properties:
+                              auto:
+                                <<: *TypeStringBool
+                                description: "Auto-generate shared secret value to secure cluster communications"
+                              value:
+                                description: "Cluster shared secret value in plain text"
                                 type: string
-                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
-                              logVolumeClaimTemplate:
-                                type: string
-                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
-                              serviceTemplate:
-                                type: string
-                                description: "optional, fully ignores for cluster-level"
-                              clusterServiceTemplate:
-                                type: string
-                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
-                              shardServiceTemplate:
-                                type: string
-                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
-                              replicaServiceTemplate:
-                                type: string
-                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
-                              volumeClaimTemplate:
-                                type: string
-                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                              valueFrom:
+                                description: "Cluster shared secret source"
+                                type: object
+                                properties:
+                                  secretKeyRef:
+                                    description: |
+                                      Selects a key of a secret in the clickhouse installation namespace.
+                                      Should not be used if value is not empty.
+                                    type: object
+                                    properties:
+                                      name:
+                                        description: |
+                                          Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      key:
+                                        description: The key of the secret to select from. Must be a valid secret key.
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                      - name
+                                      - key
                           layout:
                             type: object
                             description: |
@@ -2011,7 +1811,6 @@ spec:
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
-
                                     definitionType:
                                       type: string
                                       description: "DEPRECATED - to be removed soon"
@@ -2021,88 +1820,29 @@ spec:
                                         optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
                                         will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
                                         More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
-                                    # Need to be StringBool
                                     internalReplication:
-                                      type: string
+                                      <<: *TypeStringBool
                                       description: |
                                         optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
                                         allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
                                         will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
                                         More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
-                                      enum:
-                                        # List StringBoolXXX constants from model
-                                        - ""
-                                        - "0"
-                                        - "1"
-                                        - "False"
-                                        - "false"
-                                        - "True"
-                                        - "true"
-                                        - "No"
-                                        - "no"
-                                        - "Yes"
-                                        - "yes"
-                                        - "Off"
-                                        - "off"
-                                        - "On"
-                                        - "on"
-                                        - "Disable"
-                                        - "disable"
-                                        - "Enable"
-                                        - "enable"
-                                        - "Disabled"
-                                        - "disabled"
-                                        - "Enabled"
-                                        - "enabled"
                                     settings:
-                                      type: object
-                                      # nullable: true
+                                      <<: *TypeSettings
                                       description: |
                                         optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
                                         override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
                                         More details: https://clickhouse.tech/docs/en/operations/settings/settings/
-                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
-                                      type: object
-                                      # nullable: true
+                                      <<: *TypeFiles
                                       description: |
                                         optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
                                         override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
-                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
-                                      type: object
+                                      <<: *TypeTemplateNames
                                       description: |
                                         optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
                                         override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
-                                      # nullable: true
-                                      properties:
-                                        hostTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
-                                        podTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                        dataVolumeClaimTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                        logVolumeClaimTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                        serviceTemplate:
-                                          type: string
-                                          description: "optional, fully ignores for shard-level"
-                                        clusterServiceTemplate:
-                                          type: string
-                                          description: "optional, fully ignores for shard-level"
-                                        shardServiceTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
-                                        replicaServiceTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
-                                        volumeClaimTemplate:
-                                          type: string
-                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     replicasCount:
                                       type: integer
                                       description: |
@@ -2126,6 +1866,14 @@ spec:
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          insecure:
+                                            <<: *TypeStringBool
+                                            description: |
+                                              optional, open insecure ports for cluster, defaults to "yes"
+                                          secure:
+                                            <<: *TypeStringBool
+                                            description: |
+                                              optional, open secure ports
                                           tcpPort:
                                             type: integer
                                             description: |
@@ -2133,11 +1881,19 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          tlsPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
                                           httpPort:
                                             type: integer
                                             description: |
                                               optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
                                               allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpsPort:
+                                            type: integer
                                             minimum: 1
                                             maximum: 65535
                                           interserverHTTPPort:
@@ -2148,54 +1904,21 @@ spec:
                                             minimum: 1
                                             maximum: 65535
                                           settings:
-                                            type: object
-                                            # nullable: true
+                                            <<: *TypeSettings
                                             description: |
                                               optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
                                               override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
                                               More details: https://clickhouse.tech/docs/en/operations/settings/settings/
-                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
-                                            type: object
-                                            # nullable: true
+                                            <<: *TypeFiles
                                             description: |
                                               optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
                                               override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
-                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
-                                            type: object
+                                            <<: *TypeTemplateNames
                                             description: |
                                               optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
                                               override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
-                                            # nullable: true
-                                            properties:
-                                              hostTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
-                                              podTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
-                                              dataVolumeClaimTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                              logVolumeClaimTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                              serviceTemplate:
-                                                type: string
-                                                description: "optional, fully ignores for replica-level"
-                                              clusterServiceTemplate:
-                                                type: string
-                                                description: "optional, fully ignores for replica-level"
-                                              shardServiceTemplate:
-                                                type: string
-                                                description: "optional, fully ignores for replica-level"
-                                              replicaServiceTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
-                                              volumeClaimTemplate:
-                                                type: string
-                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                               replicas:
                                 type: array
                                 description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
@@ -2211,54 +1934,21 @@ spec:
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
                                     settings:
-                                      type: object
+                                      <<: *TypeSettings
                                       description: |
                                         optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
                                         override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
                                         More details: https://clickhouse.tech/docs/en/operations/settings/settings/
-                                      # nullable: true
-                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
-                                      type: object
-                                      # nullable: true
+                                      <<: *TypeFiles
                                       description: |
                                         optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
                                         override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
-                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
-                                      type: object
+                                      <<: *TypeTemplateNames
                                       description: |
                                         optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
                                         override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
-                                      # nullable: true
-                                      properties:
-                                        hostTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
-                                        podTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
-                                        dataVolumeClaimTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                        logVolumeClaimTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                        serviceTemplate:
-                                          type: string
-                                          description: "optional, fully ignores for replica-level"
-                                        clusterServiceTemplate:
-                                          type: string
-                                          description: "optional, fully ignores for replica-level"
-                                        shardServiceTemplate:
-                                          type: string
-                                          description: "optional, fully ignores for replica-level"
-                                        replicaServiceTemplate:
-                                          type: string
-                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
-                                        volumeClaimTemplate:
-                                          type: string
-                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     shardsCount:
                                       type: integer
                                       description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
@@ -2278,6 +1968,14 @@ spec:
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          insecure:
+                                            <<: *TypeStringBool
+                                            description: |
+                                              optional, open insecure ports for cluster, defaults to "yes"
+                                          secure:
+                                            <<: *TypeStringBool
+                                            description: |
+                                              optional, open secure ports
                                           tcpPort:
                                             type: integer
                                             description: |
@@ -2285,11 +1983,19 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          tlsPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
                                           httpPort:
                                             type: integer
                                             description: |
                                               optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
                                               allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpsPort:
+                                            type: integer
                                             minimum: 1
                                             maximum: 65535
                                           interserverHTTPPort:
@@ -2300,54 +2006,21 @@ spec:
                                             minimum: 1
                                             maximum: 65535
                                           settings:
-                                            type: object
+                                            <<: *TypeSettings
                                             description: |
                                               optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
                                               override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
                                               More details: https://clickhouse.tech/docs/en/operations/settings/settings/
-                                            # nullable: true
-                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
-                                            type: object
+                                            <<: *TypeFiles
                                             description: |
                                               optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
                                               override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
-                                            # nullable: true
-                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
-                                            type: object
+                                            <<: *TypeTemplateNames
                                             description: |
                                               optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
                                               override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
-                                            # nullable: true
-                                            properties:
-                                              hostTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
-                                              podTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                              dataVolumeClaimTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                              logVolumeClaimTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
-                                              serviceTemplate:
-                                                type: string
-                                                description: "optional, fully ignores for shard-level"
-                                              clusterServiceTemplate:
-                                                type: string
-                                                description: "optional, fully ignores for shard-level"
-                                              shardServiceTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
-                                              replicaServiceTemplate:
-                                                type: string
-                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
-                                              volumeClaimTemplate:
-                                                type: string
-                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 templates:
                   type: object
                   description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
@@ -2393,6 +2066,14 @@ spec:
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
                                 pattern: "^[a-zA-Z0-9-]{0,15}$"
+                              insecure:
+                                <<: *TypeStringBool
+                                description: |
+                                  optional, open insecure ports for cluster, defaults to "yes"
+                              secure:
+                                <<: *TypeStringBool
+                                description: |
+                                  optional, open secure ports
                               tcpPort:
                                 type: integer
                                 description: |
@@ -2401,12 +2082,20 @@ spec:
                                   More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
+                              tlsPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
                               httpPort:
                                 type: integer
                                 description: |
                                   optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
                                   if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
                                   More info: https://clickhouse.tech/docs/en/interfaces/http/
+                                minimum: 1
+                                maximum: 65535
+                              httpsPort:
+                                type: integer
                                 minimum: 1
                                 maximum: 65535
                               interserverHTTPPort:
@@ -2418,39 +2107,17 @@ spec:
                                 minimum: 1
                                 maximum: 65535
                               settings:
-                                type: object
+                                <<: *TypeSettings
                                 description: |
                                   optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
                                   More details: https://clickhouse.tech/docs/en/operations/settings/settings/
-                                # nullable: true
-                                x-kubernetes-preserve-unknown-fields: true
                               files:
-                                type: object
+                                <<: *TypeFiles
                                 description: |
                                   optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
-                                # nullable: true
-                                x-kubernetes-preserve-unknown-fields: true
                               templates:
-                                type: object
+                                <<: *TypeTemplateNames
                                 description: "be careful, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
-                                # nullable: true
-                                properties:
-                                  hostTemplate:
-                                    type: string
-                                  podTemplate:
-                                    type: string
-                                  dataVolumeClaimTemplate:
-                                    type: string
-                                  logVolumeClaimTemplate:
-                                    type: string
-                                  serviceTemplate:
-                                    type: string
-                                  clusterServiceTemplate:
-                                    type: string
-                                  shardServiceTemplate:
-                                    type: string
-                                  replicaServiceTemplate:
-                                    type: string
 
                     podTemplates:
                       type: array
@@ -2493,7 +2160,7 @@ spec:
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            description: "define ClickHouse Pod distribution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
                             # nullable: true
                             items:
                               type: object
@@ -2566,24 +2233,19 @@ spec:
                         #  - spec
                         properties:
                           name:
+                            type: string
                             description: |
                               template name, could use to link inside
                               top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
                               cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
                               shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
                               replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
-                            type: string
-                          reclaimPolicy:
-                            type: string
-                            description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
-                            enum:
-                              - ""
-                              - "Retain"
-                              - "Delete"
+                          provisioner: *TypePVCProvisioner
+                          reclaimPolicy: *TypePVCReclaimPolicy
                           metadata:
                             type: object
                             description: |
-                              allows pass standard object's metadata from template to PVC
+                              allows to pass standard object's metadata from template to PVC
                               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                             # nullable: true
                             x-kubernetes-preserve-unknown-fields: true
@@ -2665,7 +2327,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
   labels:
-    clickhouse.altinity.com/chop: 0.18.2
+    clickhouse.altinity.com/chop: 0.21.0
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
@@ -2683,8 +2345,12 @@ spec:
         - name: namespaces
           type: string
           description: Watch namespaces
-          priority: 0 # show in standard view
           jsonPath: .status
+        - name: age
+          type: date
+          description: Age of the resource
+          # Displayed in all priorities
+          jsonPath: .metadata.creationTimestamp
       schema:
         openAPIV3Schema:
           type: object
@@ -2704,6 +2370,7 @@ spec:
               properties:
                 watch:
                   type: object
+                  description: "Parameters for watch kubernetes resources which used by clickhouse-operator deployment"
                   properties:
                     namespaces:
                       type: array
@@ -2712,6 +2379,7 @@ spec:
                         type: string
                 clickhouse:
                   type: object
+                  description: "Clickhouse related parameters used by clickhouse-operator"
                   properties:
                     configuration:
                       type: object
@@ -2730,9 +2398,10 @@ spec:
                                   description: "Path to the folder where ClickHouse configuration files unique for each instance (host) within a CHI are located. Default - conf.d"
                                 user:
                                   type: string
-                                  description: "Path to the folder where ClickHouse configuration files with users settings are located. Files are common for all instances within a CHI."
+                                  description: "Path to the folder where ClickHouse configuration files with users settings are located. Files are common for all instances within a CHI. Default - users.d"
                         user:
                           type: object
+                          description: "Default parameters for any user which will create"
                           properties:
                             default:
                               type: object
@@ -2753,19 +2422,46 @@ spec:
                                   description: "ClickHouse server configuration `<password>...</password>` for any <user>"
                         network:
                           type: object
+                          description: "Default network parameters for any user which will create"
                           properties:
                             hostRegexpTemplate:
                               type: string
                               description: "ClickHouse server configuration `<host_regexp>...</host_regexp>` for any <user>"
+                    configurationRestartPolicy:
+                      type: object
+                      description: "Configuration restart policy describes what configuration changes require ClickHouse restart"
+                      properties:
+                        rules:
+                          type: array
+                          description: "Array of set of rules per specified ClickHouse versions"
+                          items:
+                            type: object
+                            properties:
+                              version:
+                                type: string
+                                description: "ClickHouse version expression"
+                              rules:
+                                type: array
+                                description: "Set of configuration rules for specified ClickHouse version"
+                                items:
+                                  type: object
+                                  description: "setting: value pairs for configuration restart policy"
                     access:
                       type: object
+                      description: "parameters which use for connect to clickhouse from clickhouse-operator deployment"
                       properties:
+                        scheme:
+                          type: string
+                          description: "The scheme to user for connecting to ClickHouse. One of http or https"
                         username:
                           type: string
                           description: "ClickHouse username to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
                         password:
                           type: string
                           description: "ClickHouse password to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
+                        rootCA:
+                          type: string
+                          description: "Root certificate authority that clients use when verifying server certificates. Used for https connection to ClickHouse"
                         secret:
                           type: object
                           properties:
@@ -2779,9 +2475,37 @@ spec:
                           type: integer
                           minimum: 1
                           maximum: 65535
-                          description: "port to be used by operator to connect to ClickHouse instances"
+                          description: "Port to be used by operator to connect to ClickHouse instances"
+                        timeouts:
+                          type: object
+                          description: "Timeouts used to limit connection and queries from the operator to ClickHouse instances, In seconds"
+                          properties:
+                            connect:
+                              type: integer
+                              minimum: 1
+                              maximum: 10
+                              description: "Connect timeout. In seconds."
+                            query:
+                              type: integer
+                              minimum: 1
+                              maximum: 600
+                              description: "Query timeout. In seconds."
+                    metrics:
+                      type: object
+                      description: "parameters which use for connect to fetch metrics from clickhouse by clickhouse-operator"
+                      properties:
+                        timeouts:
+                          type: object
+                          description: "Timeouts used to limit connection and queries from the operator to ClickHouse instances, In seconds"
+                          properties:
+                            collect:
+                              type: integer
+                              minimum: 1
+                              maximum: 600
+                              description: "Collect timeout. In seconds."
                 template:
                   type: object
+                  description: "Parameters which are used if you want to generate ClickHouseInstallationTemplate custom resources from files which are stored inside clickhouse-operator deployment"
                   properties:
                     chi:
                       type: object
@@ -2791,9 +2515,11 @@ spec:
                           description: "Path to folder where ClickHouseInstallationTemplate .yaml manifests are located."
                 reconcile:
                   type: object
+                  description: "allow tuning reconciling process"
                   properties:
                     runtime:
                       type: object
+                      description: "runtime parameters for clickhouse-operator process which use during reconciling"
                       properties:
                         threadsNumber:
                           type: integer
@@ -2802,9 +2528,11 @@ spec:
                           description: "How many goroutines will be used to reconcile in parallel, 10 by default"
                     statefulSet:
                       type: object
+                      description: "Allow change default behavior for reconciling StatefulSet which generated by clickhouse-operator"
                       properties:
                         create:
                           type: object
+                          description: "Behavior during create StatefulSet"
                           properties:
                             onFailure:
                               type: string
@@ -2816,6 +2544,7 @@ spec:
                                 3. ignore (default) - ignore error, pretend nothing happened and move on to the next StatefulSet.
                         update:
                           type: object
+                          description: "Behavior during update StatefulSet"
                           properties:
                             timeout:
                               type: integer
@@ -2833,30 +2562,69 @@ spec:
                                 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet.
                     host:
                       type: object
+                      description: "allow define how to wait host include to system.cluster behavior during scale up and scale down cluster operations"
                       properties:
                         wait:
                           type: object
                           properties:
-                            exclude:
-                              type: boolean
+                            exclude:  &TypeStringBool
+                              type: string
+                              description: "wait when a pod will be removed from the cluster"
+                              enum:
+                                # List StringBoolXXX constants from model
+                                - ""
+                                - "0"
+                                - "1"
+                                - "False"
+                                - "false"
+                                - "True"
+                                - "true"
+                                - "No"
+                                - "no"
+                                - "Yes"
+                                - "yes"
+                                - "Off"
+                                - "off"
+                                - "On"
+                                - "on"
+                                - "Disable"
+                                - "disable"
+                                - "Enable"
+                                - "enable"
+                                - "Disabled"
+                                - "disabled"
+                                - "Enabled"
+                                - "enabled"
                             include:
-                              type: boolean
+                              <<: *TypeStringBool
+                              description: "wait when a pod will be added to the cluster"
                 annotation:
                   type: object
+                  description: "defines which metadata.annotations items will include or exclude during render StatefulSet, Pod, PVC resources"
                   properties:
                     include:
                       type: array
+                      description: |
+                        When propagating labels from the chi's `metadata.annotations` section to child objects' `metadata.annotations`,
+                        include annotations with names from the following list
                       items:
                         type: string
                     exclude:
                       type: array
+                      description: |
+                        When propagating labels from the chi's `metadata.annotations` section to child objects' `metadata.annotations`,
+                        exclude annotations with names from the following list
                       items:
                         type: string
                 label:
                   type: object
+                  description: "defines which metadata.labels will include or exclude during render StatefulSet, Pod, PVC resources"
                   properties:
                     include:
                       type: array
+                      description: |
+                        When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
+                        include labels from the following list
                       items:
                         type: string
                     exclude:
@@ -2867,7 +2635,7 @@ spec:
                         When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
                         exclude labels from the following list
                     appendScope:
-                      type: string
+                      <<: *TypeStringBool
                       description: |
                         Whether to append *Scope* labels to StatefulSet and Pod
                         - "LabelShardScopeIndex"
@@ -2880,43 +2648,28 @@ spec:
                         - "LabelClusterScopeCycleSize"
                         - "LabelClusterScopeCycleIndex"
                         - "LabelClusterScopeCycleOffset"
-                      enum:
-                        # List StringBoolXXX constants from model
-                        - ""
-                        - "0"
-                        - "1"
-                        - "False"
-                        - "false"
-                        - "True"
-                        - "true"
-                        - "No"
-                        - "no"
-                        - "Yes"
-                        - "yes"
-                        - "Off"
-                        - "off"
-                        - "On"
-                        - "on"
-                        - "Disable"
-                        - "disable"
-                        - "Enable"
-                        - "enable"
-                        - "Disabled"
-                        - "disabled"
-                        - "Enabled"
-                        - "enabled"
                 statefulSet:
                   type: object
+                  description: "define StatefulSet-specific parameters"
                   properties:
                     revisionHistoryLimit:
                       type: integer
+                      description: |
+                        revisionHistoryLimit is the maximum number of revisions that will be
+                        maintained in the StatefulSet's revision history.                         
+                        Look details in `statefulset.spec.revisionHistoryLimit`
                 pod:
                   type: object
+                  description: "define pod specific parameters"
                   properties:
                     terminationGracePeriod:
                       type: integer
+                      description: |
+                        Optional duration in seconds the pod needs to terminate gracefully. 
+                        Look details in `pod.spec.terminationGracePeriodSeconds`
                 logger:
                   type: object
+                  description: "allow setup clickhouse-operator logger behavior"
                   properties:
                     logtostderr:
                       type: string
@@ -2954,7 +2707,7 @@ metadata:
   name: clickhouse-operator
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.2
+    clickhouse.altinity.com/chop: 0.21.0
 ---
 # Template Parameters:
 #
@@ -2971,13 +2724,15 @@ metadata:
   name: clickhouse-operator-kube-system
   #namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.2
+    clickhouse.altinity.com/chop: 0.21.0
 rules:
 - apiGroups:
     - ""
   resources:
     - configmaps
     - services
+    - persistentvolumeclaims
+    - secrets
   verbs:
     - get
     - list
@@ -3000,17 +2755,6 @@ rules:
     - events
   verbs:
     - create
-- apiGroups:
-    - ""
-  resources:
-    - persistentvolumeclaims
-  verbs:
-    - get
-    - list
-    - patch
-    - update
-    - watch
-    - delete
 - apiGroups:
     - ""
   resources:
@@ -3128,7 +2872,7 @@ metadata:
   name: clickhouse-operator-kube-system
   #namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.2
+    clickhouse.altinity.com/chop: 0.21.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -3150,19 +2894,23 @@ metadata:
   name: etc-clickhouse-operator-files
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.2
+    clickhouse.altinity.com/chop: 0.21.0
     app: clickhouse-operator
 data:
   config.yaml: |
     # IMPORTANT
-    # This file is auto-generated from deploy/builder/templates-config.
-    # It will be overwritten upon next sources build.
+    # This file is auto-generated
+    # Do not edit this file - all changes would be lost
+    # Edit appropriate template in the following folder:
+    # deploy/builder/templates-config
+    # IMPORTANT
     #
     # Template parameters available:
-    #   watchNamespaces
-    #   chUsername
-    #   chPassword
-    #   password_sha256_hex
+    #   WATCH_NAMESPACES=
+    #   CH_USERNAME_PLAIN=
+    #   CH_PASSWORD_PLAIN=
+    #   CH_CREDENTIALS_SECRET_NAMESPACE=
+    #   CH_CREDENTIALS_SECRET_NAME=clickhouse-operator
     
     ################################################
     ##
@@ -3171,7 +2919,7 @@ data:
     ################################################
     watch:
       # List of namespaces where clickhouse-operator watches for events.
-      # Concurrently running operators should watch on different namespaces
+      # Concurrently running operators should watch on different namespaces.
       #namespaces: ["dev", "test"]
       namespaces: []
     
@@ -3188,7 +2936,7 @@ data:
             common: config.d
             # Path to the folder where ClickHouse configuration files unique for each instance (host) within a CHI are located.
             host: conf.d
-            # Path to the folder where ClickHouse configuration files with users settings are located.
+            # Path to the folder where ClickHouse configuration files with users' settings are located.
             # Files are common for all instances within a CHI.
             user: users.d
         ################################################
@@ -3197,14 +2945,21 @@ data:
         ##
         ################################################
         user:
+          # Default settings for user accounts, created by the operator.
+          # NB. These are not access credentials or settings for 'default' user account,
+          # it is a template for filling out missing fields for all user accounts to be created by the operator, except:
+          # 1. 'default' account, which DOES NOT use provided password, but uses all the rest of the fields
+          # Password for 'default' account as to be provided explicitly, if to be used
+          # 2. CHOP account, which DOES NOT use profile, quota, password and regexp, but uses network IPs - extending them
+          # Password for CHOP account is used from `clickhouse.access.password` section
           default:
             # Default values for ClickHouse user configuration
             # 1. user/profile - string
             # 2. user/quota - string
             # 3. user/networks/ip - multiple strings
             # 4. user/password - string
-            profile: default
-            quota: default
+            profile: "default"
+            quota: "default"
             networksIP:
               - "::1"
               - "127.0.0.1"
@@ -3217,28 +2972,83 @@ data:
         network:
           # Default host_regexp to limit network connectivity from outside
           hostRegexpTemplate: "(chi-{chi}-[^.]+\\d+-\\d+|clickhouse\\-{chi})\\.{namespace}\\.svc\\.cluster\\.local$"
+    
       ################################################
+      ##
+      ## Configuration Restart Policy Section
+      ## Configuration restart policy describes what configuration changes require ClickHouse restart
+      ##
+      ################################################
+      configurationRestartPolicy:
+        rules:
+          - version: "*"
+            rules:
+              - settings/*: "yes"
+              - settings/dictionaries_config: "no"
+              - settings/logger: "no"
+              - settings/macros/*: "no"
+              - settings/max_server_memory_*: "no"
+              - settings/max_*_to_drop: "no"
+              - settings/max_concurrent_queries: "no"
+              - settings/models_config: "no"
+              - settings/user_defined_executable_functions_config: "no"
+    
+              - zookeeper/*: "yes"
+    
+              - files/config.d/*.xml: "yes"
+              - files/config.d/*dict*.xml: "no"
+    
+              - profiles/default/background_*_pool_size: "yes"
+              - profiles/default/max_*_for_server: "yes"
+          - version: "21.*"
+            rules:
+              - settings/logger: "yes"
+    
+      #################################################
       ##
       ## Access to ClickHouse instances
       ##
       ################################################
       access:
-        # ClickHouse credentials (username, password and port) to be used by operator to connect to ClickHouse instances
-        # for:
+        # Possible values for `scheme` are:
+        # 1. http
+        # 2. https
+        scheme: ""
+        # ClickHouse credentials (username, password and port) to be used by the operator to connect to ClickHouse instances.
+        # Used for:
         # 1. Metrics requests
         # 2. Schema maintenance
         # 3. DROP DNS CACHE
-        # User with such credentials can be specified in additional ClickHouse .xml config files,
-        # located in `chUsersConfigsPath` folder
-        username: "clickhouse_operator"
-        password: "clickhouse_operator_password"
+        # User with these credentials can be specified in additional ClickHouse .xml config files,
+        # located in `clickhouse.configuration.file.path.user` folder
+        username: ""
+        password: ""
+        rootCA: ""
+    
+        # Location of the k8s Secret with username and password to be used by the operator to connect to ClickHouse instances.
+        # Can be used instead of explicitly specified username and password which are:
+        # clickhouse.access.username
+        # clickhouse.access.password
+        # Secret should have two keys:
+        # 1. username
+        # 2. password
         secret:
-          # Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances
-          # Can be used instead of explicitly specified username and password
+          # Empty `namespace` means that k8s secret would be looked in the same namespace where operator's pod is running.
           namespace: ""
-          name: ""
+          # Empty `name` means no k8s Secret would be looked for
+          name: "clickhouse-operator"
         # Port where to connect to ClickHouse instances to
         port: 8123
+    
+        # Timeouts used to limit connection and queries from the operator to ClickHouse instances
+        # Specified in seconds.
+        timeouts:
+          connect: 2
+          query: 5
+    
+      metrics:
+        timeouts:
+          collect: 9
     
     ################################################
     ##
@@ -3263,27 +3073,32 @@ data:
     
       statefulSet:
         create:
-          # What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+          # What to do in case created StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds
           # Possible options:
-          # 1. abort - do nothing, just break the process and wait for admin
+          # 1. abort - do nothing, just break the process and wait for an admin to assist
           # 2. delete - delete newly created problematic StatefulSet
-          # 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet
+          # 3. ignore - ignore an error, pretend nothing happened and move on to the next StatefulSet
           onFailure: ignore
     
         update:
-          # How many seconds to wait for created/updated StatefulSet to be Ready
+          # How many seconds to wait for created/updated StatefulSet to be 'Ready'
           timeout: 300
-          # How many seconds to wait between checks for created/updated StatefulSet status
+          # How many seconds to wait between checks/polls for created/updated StatefulSet status
           pollInterval: 5
-          # What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+          # What to do in case updated StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds
           # Possible options:
-          # 1. abort - do nothing, just break the process and wait for admin
+          # 1. abort - do nothing, just break the process and wait for an admin to assist
           # 2. rollback - delete Pod and rollback StatefulSet to previous Generation.
           # Pod would be recreated by StatefulSet based on rollback-ed configuration
-          # 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet
+          # 3. ignore - ignore an error, pretend nothing happened and move on to the next StatefulSet
           onFailure: rollback
     
       host:
+        # Whether reconciler should wait for a host:
+        # - to be excluded from a cluster
+        # OR
+        # - to be included into a cluster
+        # respectfully
         wait:
           exclude: true
           include: false
@@ -3316,9 +3131,10 @@ data:
       # Applied only when not empty. Empty list means "include all, no selection"
       include: []
       # Exclude labels from the following list:
+      # Applied only when not empty. Empty list means "nothing to exclude, no selection"
       exclude: []
       # Whether to append *Scope* labels to StatefulSet and Pod.
-      # Full list of available *scope* labels check in labeler.go
+      # Full list of available *scope* labels check in 'labeler.go'
       #  LabelShardScopeIndex
       #  LabelReplicaScopeIndex
       #  LabelCHIScopeIndex
@@ -3377,7 +3193,7 @@ metadata:
   name: etc-clickhouse-operator-confd-files
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.2
+    clickhouse.altinity.com/chop: 0.21.0
     app: clickhouse-operator
 data:
 ---
@@ -3393,10 +3209,16 @@ metadata:
   name: etc-clickhouse-operator-configd-files
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.2
+    clickhouse.altinity.com/chop: 0.21.0
     app: clickhouse-operator
 data:
   01-clickhouse-01-listen.xml: |
+    <!-- IMPORTANT -->
+    <!-- This file is auto-generated -->
+    <!-- Do not edit this file - all changes would be lost -->
+    <!-- Edit appropriate template in the following folder: -->
+    <!-- deploy/builder/templates-config -->
+    <!-- IMPORTANT -->
     <yandex>
         <!-- Listen wildcard address to allow accepting connections from other containers and host network. -->
         <listen_host>::</listen_host>
@@ -3405,6 +3227,12 @@ data:
     </yandex>
 
   01-clickhouse-02-logger.xml: |
+    <!-- IMPORTANT -->
+    <!-- This file is auto-generated -->
+    <!-- Do not edit this file - all changes would be lost -->
+    <!-- Edit appropriate template in the following folder: -->
+    <!-- deploy/builder/templates-config -->
+    <!-- IMPORTANT -->
     <yandex>
         <logger>
             <!-- Possible levels: https://github.com/pocoproject/poco/blob/develop/Foundation/include/Poco/Logger.h#L105 -->
@@ -3419,6 +3247,12 @@ data:
     </yandex>
 
   01-clickhouse-03-query_log.xml: |
+    <!-- IMPORTANT -->
+    <!-- This file is auto-generated -->
+    <!-- Do not edit this file - all changes would be lost -->
+    <!-- Edit appropriate template in the following folder: -->
+    <!-- deploy/builder/templates-config -->
+    <!-- IMPORTANT -->
     <yandex>
         <query_log replace="1">
             <database>system</database>
@@ -3430,6 +3264,12 @@ data:
     </yandex>
 
   01-clickhouse-04-part_log.xml: |
+    <!-- IMPORTANT -->
+    <!-- This file is auto-generated -->
+    <!-- Do not edit this file - all changes would be lost -->
+    <!-- Edit appropriate template in the following folder: -->
+    <!-- deploy/builder/templates-config -->
+    <!-- IMPORTANT -->
     <yandex>
         <part_log replace="1">
             <database>system</database>
@@ -3452,7 +3292,7 @@ metadata:
   name: etc-clickhouse-operator-templatesd-files
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.2
+    clickhouse.altinity.com/chop: 0.21.0
     app: clickhouse-operator
 data:
   001-templates.json.example: |
@@ -3487,7 +3327,7 @@ data:
                 "containers" : [
                   {
                     "name": "clickhouse",
-                    "image": "projects.registry.vmware.com/antrea/theia-clickhouse-server:22.6",
+                    "image": "projects.registry.vmware.com/antrea/theia-clickhouse-server:23.4",
                     "ports": [
                       {
                         "name": "http",
@@ -3552,59 +3392,84 @@ metadata:
   name: etc-clickhouse-operator-usersd-files
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.2
+    clickhouse.altinity.com/chop: 0.21.0
     app: clickhouse-operator
 data:
-  01-clickhouse-user.xml: |
+  01-clickhouse-operator-profile.xml: |
+    <!-- IMPORTANT -->
+    <!-- This file is auto-generated -->
+    <!-- Do not edit this file - all changes would be lost -->
+    <!-- Edit appropriate template in the following folder: -->
+    <!-- deploy/builder/templates-config -->
+    <!-- IMPORTANT -->
+    <!--
+    #
+    # Template parameters available:
+    #
+    -->
     <yandex>
-        <users>
-            <clickhouse_operator>
-                <networks>
-                    <ip>127.0.0.1</ip>
-                    <ip>0.0.0.0/0</ip>
-                    <ip>::/0</ip>
-                </networks>
-                <password_sha256_hex>716b36073a90c6fe1d445ac1af85f4777c5b7a155cea359961826a030513e448</password_sha256_hex>
-                <profile>clickhouse_operator</profile>
-                <quota>default</quota>
-            </clickhouse_operator>
-        </users>
+        <!-- clickhouse-operator user is generated by the operator based on config.yaml in runtime -->
         <profiles>
             <clickhouse_operator>
                 <log_queries>0</log_queries>
                 <skip_unavailable_shards>1</skip_unavailable_shards>
                 <http_connection_timeout>10</http_connection_timeout>
+                <max_concurrent_queries_for_all_users>0</max_concurrent_queries_for_all_users>
+                <os_thread_priority>0</os_thread_priority>
             </clickhouse_operator>
         </profiles>
     </yandex>
 
   02-clickhouse-default-profile.xml: |
+    <!-- IMPORTANT -->
+    <!-- This file is auto-generated -->
+    <!-- Do not edit this file - all changes would be lost -->
+    <!-- Edit appropriate template in the following folder: -->
+    <!-- deploy/builder/templates-config -->
+    <!-- IMPORTANT -->
     <yandex>
       <profiles>
         <default>
+          <os_thread_priority>2</os_thread_priority>
           <log_queries>1</log_queries>
           <connect_timeout_with_failover_ms>1000</connect_timeout_with_failover_ms>
           <distributed_aggregation_memory_efficient>1</distributed_aggregation_memory_efficient>
           <parallel_view_processing>1</parallel_view_processing>
+          <do_not_merge_across_partitions_select_final>1</do_not_merge_across_partitions_select_final>
+          <load_balancing>nearest_hostname</load_balancing>
         </default>
       </profiles>
     </yandex>
-  03-database-ordinary.xml: |
-    <!--  Remove it for ClickHouse versions before 20.4 -->
-    <yandex>
-        <profiles>
-            <default>
-                <default_database_engine>Ordinary</default_database_engine>
-            </default>
-        </profiles>
-    </yandex>
+---
+#
+# Template parameters available:
+#   NAMESPACE=kube-system
+#   COMMENT=
+#   OPERATOR_VERSION=0.21.0
+#   CH_USERNAME_SECRET_PLAIN=clickhouse_operator
+#   CH_PASSWORD_SECRET_PLAIN=clickhouse_operator_password
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: clickhouse-operator
+  namespace: kube-system
+  labels:
+    clickhouse.altinity.com/chop: 0.21.0
+    app: clickhouse-operator
+type: Opaque
+stringData:
+  username: clickhouse_operator
+  password: clickhouse_operator_password
 ---
 # Template Parameters:
 #
 # NAMESPACE=kube-system
 # COMMENT=
-# OPERATOR_IMAGE=projects.registry.vmware.com/antrea/theia-clickhouse-operator:0.18.2
-# METRICS_EXPORTER_IMAGE=projects.registry.vmware.com/antrea/theia-metrics-exporter:0.18.2
+# OPERATOR_IMAGE=projects.registry.vmware.com/antrea/clickhouse-operator:0.21.0
+# OPERATOR_IMAGE_PULL_POLICY=Always
+# METRICS_EXPORTER_IMAGE=projects.registry.vmware.com/antrea/clickhouse-operator:0.21.0
+# METRICS_EXPORTER_IMAGE_PULL_POLICY=Always
 #
 # Setup Deployment for clickhouse-operator
 # Deployment would be created in kubectl-specified namespace
@@ -3614,7 +3479,7 @@ metadata:
   name: clickhouse-operator
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.2
+    clickhouse.altinity.com/chop: 0.21.0
     app: clickhouse-operator
 spec:
   replicas: 1
@@ -3648,7 +3513,7 @@ spec:
             name: etc-clickhouse-operator-usersd-files
       containers:
         - name: clickhouse-operator
-          image: projects.registry.vmware.com/antrea/theia-clickhouse-operator:0.18.2
+          image: projects.registry.vmware.com/antrea/clickhouse-operator:0.21.0
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: etc-clickhouse-operator-folder
@@ -3713,7 +3578,7 @@ spec:
                   resource: limits.memory
 
         - name: metrics-exporter
-          image: projects.registry.vmware.com/antrea/theia-metrics-exporter:0.18.2
+          image: projects.registry.vmware.com/antrea/metrics-exporter:0.21.0
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: etc-clickhouse-operator-folder
@@ -3726,6 +3591,56 @@ spec:
               mountPath: /etc/clickhouse-operator/templates.d
             - name: etc-clickhouse-operator-usersd-folder
               mountPath: /etc/clickhouse-operator/users.d
+          env:
+            # Pod-specific
+            # spec.nodeName: ip-172-20-52-62.ec2.internal
+            - name: OPERATOR_POD_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # metadata.name: clickhouse-operator-6f87589dbb-ftcsf
+            - name: OPERATOR_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # metadata.namespace: kube-system
+            - name: OPERATOR_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # status.podIP: 100.96.3.2
+            - name: OPERATOR_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # spec.serviceAccount: clickhouse-operator
+            # spec.serviceAccountName: clickhouse-operator
+            - name: OPERATOR_POD_SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+
+            # Container-specific
+            - name: OPERATOR_CONTAINER_CPU_REQUEST
+              valueFrom:
+                resourceFieldRef:
+                  containerName: clickhouse-operator
+                  resource: requests.cpu
+            - name: OPERATOR_CONTAINER_CPU_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: clickhouse-operator
+                  resource: limits.cpu
+            - name: OPERATOR_CONTAINER_MEM_REQUEST
+              valueFrom:
+                resourceFieldRef:
+                  containerName: clickhouse-operator
+                  resource: requests.memory
+            - name: OPERATOR_CONTAINER_MEM_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: clickhouse-operator
+                  resource: limits.memory
           ports:
             - containerPort: 8888
               name: metrics
@@ -3746,7 +3661,7 @@ metadata:
   name: clickhouse-operator-metrics
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.2
+    clickhouse.altinity.com/chop: 0.21.0
     app: clickhouse-operator
 spec:
   ports:

--- a/build/charts/theia/provisioning/datasources/migrators/000005_0-6-0.down.sql
+++ b/build/charts/theia/provisioning/datasources/migrators/000005_0-6-0.down.sql
@@ -1,0 +1,192 @@
+DROP VIEW flows_pod_view_local;
+DROP VIEW flows_node_view_local;
+DROP VIEW flows_policy_view_local;
+
+--Create a Materialized View to aggregate data for pods
+CREATE MATERIALIZED VIEW IF NOT EXISTS flows_pod_view_local
+ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
+ORDER BY (
+    timeInserted,
+    flowEndSeconds,
+    flowEndSecondsFromSourceNode,
+    flowEndSecondsFromDestinationNode,
+    sourcePodName,
+    destinationPodName,
+    destinationIP,
+    destinationServicePort,
+    destinationServicePortName,
+    flowType,
+    sourcePodNamespace,
+    destinationPodNamespace,
+    sourceTransportPort,
+    destinationTransportPort,
+    clusterUUID)
+POPULATE
+AS SELECT
+    timeInserted,
+    flowEndSeconds,
+    flowEndSecondsFromSourceNode,
+    flowEndSecondsFromDestinationNode,
+    sourcePodName,
+    destinationPodName,
+    destinationIP,
+    destinationServicePort,
+    destinationServicePortName,
+    flowType,
+    sourcePodNamespace,
+    destinationPodNamespace,
+    sourceTransportPort,
+    destinationTransportPort,
+    sum(octetDeltaCount) AS octetDeltaCount,
+    sum(reverseOctetDeltaCount) AS reverseOctetDeltaCount,
+    sum(throughput) AS throughput,
+    sum(reverseThroughput) AS reverseThroughput,
+    sum(throughputFromSourceNode) AS throughputFromSourceNode,
+    sum(throughputFromDestinationNode) AS throughputFromDestinationNode,
+    clusterUUID
+FROM flows_local
+GROUP BY
+    timeInserted,
+    flowEndSeconds,
+    flowEndSecondsFromSourceNode,
+    flowEndSecondsFromDestinationNode,
+    sourcePodName,
+    destinationPodName,
+    destinationIP,
+    destinationServicePort,
+    destinationServicePortName,
+    flowType,
+    sourcePodNamespace,
+    destinationPodNamespace,
+    sourceTransportPort,
+    destinationTransportPort,
+    clusterUUID;
+
+--Create a Materialized View to aggregate data for nodes
+CREATE MATERIALIZED VIEW IF NOT EXISTS flows_node_view_local
+ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
+ORDER BY (
+    timeInserted,
+    flowEndSeconds,
+    flowEndSecondsFromSourceNode,
+    flowEndSecondsFromDestinationNode,
+    sourceNodeName,
+    destinationNodeName,
+    sourcePodNamespace,
+    destinationPodNamespace,
+    clusterUUID)
+POPULATE
+AS SELECT
+    timeInserted,
+    flowEndSeconds,
+    flowEndSecondsFromSourceNode,
+    flowEndSecondsFromDestinationNode,
+    sourceNodeName,
+    destinationNodeName,
+    sourcePodNamespace,
+    destinationPodNamespace,
+    sum(octetDeltaCount) AS octetDeltaCount,
+    sum(reverseOctetDeltaCount) AS reverseOctetDeltaCount,
+    sum(throughput) AS throughput,
+    sum(reverseThroughput) AS reverseThroughput,
+    sum(throughputFromSourceNode) AS throughputFromSourceNode,
+    sum(reverseThroughputFromSourceNode) AS reverseThroughputFromSourceNode,
+    sum(throughputFromDestinationNode) AS throughputFromDestinationNode,
+    sum(reverseThroughputFromDestinationNode) AS reverseThroughputFromDestinationNode,
+    clusterUUID
+FROM flows_local
+GROUP BY
+    timeInserted,
+    flowEndSeconds,
+    flowEndSecondsFromSourceNode,
+    flowEndSecondsFromDestinationNode,
+    sourceNodeName,
+    destinationNodeName,
+    sourcePodNamespace,
+    destinationPodNamespace,
+    clusterUUID;
+
+--Create a Materialized View to aggregate data for network policies
+CREATE MATERIALIZED VIEW IF NOT EXISTS flows_policy_view_local
+ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
+ORDER BY (
+    timeInserted,
+    flowEndSeconds,
+    flowEndSecondsFromSourceNode,
+    flowEndSecondsFromDestinationNode,
+    egressNetworkPolicyName,
+    egressNetworkPolicyNamespace,
+    egressNetworkPolicyRuleAction,
+    ingressNetworkPolicyName,
+    ingressNetworkPolicyNamespace,
+    ingressNetworkPolicyRuleAction,
+    sourcePodName,
+    sourceTransportPort,
+    sourcePodNamespace,
+    destinationPodName,
+    destinationTransportPort,
+    destinationPodNamespace,
+    destinationServicePort,
+    destinationServicePortName,
+    destinationIP,
+    clusterUUID)
+POPULATE
+AS SELECT
+    timeInserted,
+    flowEndSeconds,
+    flowEndSecondsFromSourceNode,
+    flowEndSecondsFromDestinationNode,
+    egressNetworkPolicyName,
+    egressNetworkPolicyNamespace,
+    egressNetworkPolicyRuleAction,
+    ingressNetworkPolicyName,
+    ingressNetworkPolicyNamespace,
+    ingressNetworkPolicyRuleAction,
+    sourcePodName,
+    sourceTransportPort,
+    sourcePodNamespace,
+    destinationPodName,
+    destinationTransportPort,
+    destinationPodNamespace,
+    destinationServicePort,
+    destinationServicePortName,
+    destinationIP,
+    sum(octetDeltaCount) AS octetDeltaCount,
+    sum(reverseOctetDeltaCount) AS reverseOctetDeltaCount,
+    sum(throughput) AS throughput,
+    sum(reverseThroughput) AS reverseThroughput,
+    sum(throughputFromSourceNode) AS throughputFromSourceNode,
+    sum(reverseThroughputFromSourceNode) AS reverseThroughputFromSourceNode,
+    sum(throughputFromDestinationNode) AS throughputFromDestinationNode,
+    sum(reverseThroughputFromDestinationNode) AS reverseThroughputFromDestinationNode,
+    clusterUUID
+FROM flows_local
+GROUP BY
+    timeInserted,
+    flowEndSeconds,
+    flowEndSecondsFromSourceNode,
+    flowEndSecondsFromDestinationNode,
+    egressNetworkPolicyName,
+    egressNetworkPolicyNamespace,
+    egressNetworkPolicyRuleAction,
+    ingressNetworkPolicyName,
+    ingressNetworkPolicyNamespace,
+    ingressNetworkPolicyRuleAction,
+    sourcePodName,
+    sourceTransportPort,
+    sourcePodNamespace,
+    destinationPodName,
+    destinationTransportPort,
+    destinationPodNamespace,
+    destinationServicePort,
+    destinationServicePortName,
+    destinationIP,
+    clusterUUID;
+
+INSERT INTO ".inner.flows_pod_view_local" SELECT * FROM pod_view_table_local;
+INSERT INTO ".inner.flows_node_view_local" SELECT * FROM node_view_table_local;
+INSERT INTO ".inner.flows_policy_view_local" SELECT * FROM policy_view_table_local;
+
+DROP TABLE pod_view_table_local;
+DROP TABLE node_view_table_local;
+DROP TABLE policy_view_table_local;

--- a/build/charts/theia/provisioning/datasources/migrators/000005_0-6-0.up.sql
+++ b/build/charts/theia/provisioning/datasources/migrators/000005_0-6-0.up.sql
@@ -1,0 +1,131 @@
+-- Create underlying tables for Materialized Views to attach data
+CREATE TABLE IF NOT EXISTS pod_view_table_local (
+    timeInserted DateTime DEFAULT now(),
+    flowEndSeconds DateTime,
+    flowEndSecondsFromSourceNode DateTime,
+    flowEndSecondsFromDestinationNode DateTime,
+    sourcePodName String,
+    destinationPodName String,
+    destinationIP String,
+    destinationServicePort UInt16,
+    destinationServicePortName String,
+    flowType UInt8,
+    sourcePodNamespace String,
+    destinationPodNamespace String,
+    sourceTransportPort UInt16,
+    destinationTransportPort UInt16,
+    octetDeltaCount UInt64,
+    reverseOctetDeltaCount UInt64,
+    throughput UInt64,
+    reverseThroughput UInt64,
+    throughputFromSourceNode UInt64,
+    throughputFromDestinationNode UInt64,
+    clusterUUID String
+) ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
+ORDER BY (
+    timeInserted,
+    flowEndSeconds,
+    flowEndSecondsFromSourceNode,
+    flowEndSecondsFromDestinationNode,
+    sourcePodName,
+    destinationPodName,
+    destinationIP,
+    destinationServicePort,
+    destinationServicePortName,
+    flowType,
+    sourcePodNamespace,
+    destinationPodNamespace,
+    sourceTransportPort,
+    destinationTransportPort,
+    clusterUUID);
+
+CREATE TABLE IF NOT EXISTS node_view_table_local (
+    timeInserted DateTime DEFAULT now(),
+    flowEndSeconds DateTime,
+    flowEndSecondsFromSourceNode DateTime,
+    flowEndSecondsFromDestinationNode DateTime,
+    sourceNodeName String,
+    destinationNodeName String,
+    sourcePodNamespace String,
+    destinationPodNamespace String,
+    octetDeltaCount UInt64,
+    reverseOctetDeltaCount UInt64,
+    throughput UInt64,
+    reverseThroughput UInt64,
+    throughputFromSourceNode UInt64,
+    reverseThroughputFromSourceNode UInt64,
+    throughputFromDestinationNode UInt64,
+    reverseThroughputFromDestinationNode UInt64,
+    clusterUUID String
+) ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
+ORDER BY (
+    timeInserted,
+    flowEndSeconds,
+    flowEndSecondsFromSourceNode,
+    flowEndSecondsFromDestinationNode,
+    sourceNodeName,
+    destinationNodeName,
+    sourcePodNamespace,
+    destinationPodNamespace,
+    clusterUUID);
+
+CREATE TABLE IF NOT EXISTS policy_view_table_local (
+    timeInserted DateTime DEFAULT now(),
+    flowEndSeconds DateTime,
+    flowEndSecondsFromSourceNode DateTime,
+    flowEndSecondsFromDestinationNode DateTime,
+    egressNetworkPolicyName String,
+    egressNetworkPolicyNamespace String,
+    egressNetworkPolicyRuleAction UInt8,
+    ingressNetworkPolicyName String,
+    ingressNetworkPolicyNamespace String,
+    ingressNetworkPolicyRuleAction UInt8,
+    sourcePodName String,
+    sourceTransportPort UInt16,
+    sourcePodNamespace String,
+    destinationPodName String,
+    destinationTransportPort UInt16,
+    destinationPodNamespace String,
+    destinationServicePort UInt16,
+    destinationServicePortName String,
+    destinationIP String,
+    octetDeltaCount UInt64,
+    reverseOctetDeltaCount UInt64,
+    throughput UInt64,
+    reverseThroughput UInt64,
+    throughputFromSourceNode UInt64,
+    reverseThroughputFromSourceNode UInt64,
+    throughputFromDestinationNode UInt64,
+    reverseThroughputFromDestinationNode UInt64,
+    clusterUUID String
+) ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
+ORDER BY (
+    timeInserted,
+    flowEndSeconds,
+    flowEndSecondsFromSourceNode,
+    flowEndSecondsFromDestinationNode,
+    egressNetworkPolicyName,
+    egressNetworkPolicyNamespace,
+    egressNetworkPolicyRuleAction,
+    ingressNetworkPolicyName,
+    ingressNetworkPolicyNamespace,
+    ingressNetworkPolicyRuleAction,
+    sourcePodName,
+    sourceTransportPort,
+    sourcePodNamespace,
+    destinationPodName,
+    destinationTransportPort,
+    destinationPodNamespace,
+    destinationServicePort,
+    destinationServicePortName,
+    destinationIP,
+    clusterUUID);
+
+--Move data from old mv underlying tables and drop old mvs
+INSERT INTO pod_view_table_local SELECT * FROM ".inner.flows_pod_view_local";
+INSERT INTO node_view_table_local SELECT * FROM ".inner.flows_node_view_local";
+INSERT INTO policy_view_table_local SELECT * FROM ".inner.flows_policy_view_local";
+
+DROP VIEW flows_pod_view_local;
+DROP VIEW flows_node_view_local;
+DROP VIEW flows_policy_view_local;

--- a/build/charts/theia/templates/_helpers.tpl
+++ b/build/charts/theia/templates/_helpers.tpl
@@ -20,7 +20,7 @@
     - name: TABLE_NAME
       value: "default.flows_local"
     - name: MV_NAMES
-      value: "default.flows_pod_view_local default.flows_node_view_local default.flows_policy_view_local"
+      value: "default.pod_view_table_local default.node_view_table_local default.policy_view_table_local"
     - name: STORAGE_SIZE
       value: {{ $clickhouse.storage.size | quote }}
     - name: THRESHOLD

--- a/build/images/Dockerfile.clickhouse-server.ubuntu
+++ b/build/images/Dockerfile.clickhouse-server.ubuntu
@@ -6,7 +6,7 @@ WORKDIR /theia
 
 RUN make clickhouse-schema-management-plugin
 
-FROM docker.io/clickhouse/clickhouse-server:22.6
+FROM docker.io/clickhouse/clickhouse-server:23.4
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A docker image to deploy the ClickHouse server."

--- a/build/yamls/flow-visibility.yml
+++ b/build/yamls/flow-visibility.yml
@@ -388,6 +388,331 @@ data:
 
     CREATE TABLE IF NOT EXISTS tadetector AS tadetector_local
         engine=Distributed('{cluster}', default, tadetector_local, rand());
+  000005_0-6-0.down.sql: |
+    DROP VIEW flows_pod_view_local;
+    DROP VIEW flows_node_view_local;
+    DROP VIEW flows_policy_view_local;
+
+    --Create a Materialized View to aggregate data for pods
+    CREATE MATERIALIZED VIEW IF NOT EXISTS flows_pod_view_local
+    ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
+    ORDER BY (
+        timeInserted,
+        flowEndSeconds,
+        flowEndSecondsFromSourceNode,
+        flowEndSecondsFromDestinationNode,
+        sourcePodName,
+        destinationPodName,
+        destinationIP,
+        destinationServicePort,
+        destinationServicePortName,
+        flowType,
+        sourcePodNamespace,
+        destinationPodNamespace,
+        sourceTransportPort,
+        destinationTransportPort,
+        clusterUUID)
+    POPULATE
+    AS SELECT
+        timeInserted,
+        flowEndSeconds,
+        flowEndSecondsFromSourceNode,
+        flowEndSecondsFromDestinationNode,
+        sourcePodName,
+        destinationPodName,
+        destinationIP,
+        destinationServicePort,
+        destinationServicePortName,
+        flowType,
+        sourcePodNamespace,
+        destinationPodNamespace,
+        sourceTransportPort,
+        destinationTransportPort,
+        sum(octetDeltaCount) AS octetDeltaCount,
+        sum(reverseOctetDeltaCount) AS reverseOctetDeltaCount,
+        sum(throughput) AS throughput,
+        sum(reverseThroughput) AS reverseThroughput,
+        sum(throughputFromSourceNode) AS throughputFromSourceNode,
+        sum(throughputFromDestinationNode) AS throughputFromDestinationNode,
+        clusterUUID
+    FROM flows_local
+    GROUP BY
+        timeInserted,
+        flowEndSeconds,
+        flowEndSecondsFromSourceNode,
+        flowEndSecondsFromDestinationNode,
+        sourcePodName,
+        destinationPodName,
+        destinationIP,
+        destinationServicePort,
+        destinationServicePortName,
+        flowType,
+        sourcePodNamespace,
+        destinationPodNamespace,
+        sourceTransportPort,
+        destinationTransportPort,
+        clusterUUID;
+
+    --Create a Materialized View to aggregate data for nodes
+    CREATE MATERIALIZED VIEW IF NOT EXISTS flows_node_view_local
+    ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
+    ORDER BY (
+        timeInserted,
+        flowEndSeconds,
+        flowEndSecondsFromSourceNode,
+        flowEndSecondsFromDestinationNode,
+        sourceNodeName,
+        destinationNodeName,
+        sourcePodNamespace,
+        destinationPodNamespace,
+        clusterUUID)
+    POPULATE
+    AS SELECT
+        timeInserted,
+        flowEndSeconds,
+        flowEndSecondsFromSourceNode,
+        flowEndSecondsFromDestinationNode,
+        sourceNodeName,
+        destinationNodeName,
+        sourcePodNamespace,
+        destinationPodNamespace,
+        sum(octetDeltaCount) AS octetDeltaCount,
+        sum(reverseOctetDeltaCount) AS reverseOctetDeltaCount,
+        sum(throughput) AS throughput,
+        sum(reverseThroughput) AS reverseThroughput,
+        sum(throughputFromSourceNode) AS throughputFromSourceNode,
+        sum(reverseThroughputFromSourceNode) AS reverseThroughputFromSourceNode,
+        sum(throughputFromDestinationNode) AS throughputFromDestinationNode,
+        sum(reverseThroughputFromDestinationNode) AS reverseThroughputFromDestinationNode,
+        clusterUUID
+    FROM flows_local
+    GROUP BY
+        timeInserted,
+        flowEndSeconds,
+        flowEndSecondsFromSourceNode,
+        flowEndSecondsFromDestinationNode,
+        sourceNodeName,
+        destinationNodeName,
+        sourcePodNamespace,
+        destinationPodNamespace,
+        clusterUUID;
+
+    --Create a Materialized View to aggregate data for network policies
+    CREATE MATERIALIZED VIEW IF NOT EXISTS flows_policy_view_local
+    ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
+    ORDER BY (
+        timeInserted,
+        flowEndSeconds,
+        flowEndSecondsFromSourceNode,
+        flowEndSecondsFromDestinationNode,
+        egressNetworkPolicyName,
+        egressNetworkPolicyNamespace,
+        egressNetworkPolicyRuleAction,
+        ingressNetworkPolicyName,
+        ingressNetworkPolicyNamespace,
+        ingressNetworkPolicyRuleAction,
+        sourcePodName,
+        sourceTransportPort,
+        sourcePodNamespace,
+        destinationPodName,
+        destinationTransportPort,
+        destinationPodNamespace,
+        destinationServicePort,
+        destinationServicePortName,
+        destinationIP,
+        clusterUUID)
+    POPULATE
+    AS SELECT
+        timeInserted,
+        flowEndSeconds,
+        flowEndSecondsFromSourceNode,
+        flowEndSecondsFromDestinationNode,
+        egressNetworkPolicyName,
+        egressNetworkPolicyNamespace,
+        egressNetworkPolicyRuleAction,
+        ingressNetworkPolicyName,
+        ingressNetworkPolicyNamespace,
+        ingressNetworkPolicyRuleAction,
+        sourcePodName,
+        sourceTransportPort,
+        sourcePodNamespace,
+        destinationPodName,
+        destinationTransportPort,
+        destinationPodNamespace,
+        destinationServicePort,
+        destinationServicePortName,
+        destinationIP,
+        sum(octetDeltaCount) AS octetDeltaCount,
+        sum(reverseOctetDeltaCount) AS reverseOctetDeltaCount,
+        sum(throughput) AS throughput,
+        sum(reverseThroughput) AS reverseThroughput,
+        sum(throughputFromSourceNode) AS throughputFromSourceNode,
+        sum(reverseThroughputFromSourceNode) AS reverseThroughputFromSourceNode,
+        sum(throughputFromDestinationNode) AS throughputFromDestinationNode,
+        sum(reverseThroughputFromDestinationNode) AS reverseThroughputFromDestinationNode,
+        clusterUUID
+    FROM flows_local
+    GROUP BY
+        timeInserted,
+        flowEndSeconds,
+        flowEndSecondsFromSourceNode,
+        flowEndSecondsFromDestinationNode,
+        egressNetworkPolicyName,
+        egressNetworkPolicyNamespace,
+        egressNetworkPolicyRuleAction,
+        ingressNetworkPolicyName,
+        ingressNetworkPolicyNamespace,
+        ingressNetworkPolicyRuleAction,
+        sourcePodName,
+        sourceTransportPort,
+        sourcePodNamespace,
+        destinationPodName,
+        destinationTransportPort,
+        destinationPodNamespace,
+        destinationServicePort,
+        destinationServicePortName,
+        destinationIP,
+        clusterUUID;
+
+    INSERT INTO ".inner.flows_pod_view_local" SELECT * FROM pod_view_table_local;
+    INSERT INTO ".inner.flows_node_view_local" SELECT * FROM node_view_table_local;
+    INSERT INTO ".inner.flows_policy_view_local" SELECT * FROM policy_view_table_local;
+
+    DROP TABLE pod_view_table_local;
+    DROP TABLE node_view_table_local;
+    DROP TABLE policy_view_table_local;
+  000005_0-6-0.up.sql: |
+    -- Create underlying tables for Materialized Views to attach data
+    CREATE TABLE IF NOT EXISTS pod_view_table_local (
+        timeInserted DateTime DEFAULT now(),
+        flowEndSeconds DateTime,
+        flowEndSecondsFromSourceNode DateTime,
+        flowEndSecondsFromDestinationNode DateTime,
+        sourcePodName String,
+        destinationPodName String,
+        destinationIP String,
+        destinationServicePort UInt16,
+        destinationServicePortName String,
+        flowType UInt8,
+        sourcePodNamespace String,
+        destinationPodNamespace String,
+        sourceTransportPort UInt16,
+        destinationTransportPort UInt16,
+        octetDeltaCount UInt64,
+        reverseOctetDeltaCount UInt64,
+        throughput UInt64,
+        reverseThroughput UInt64,
+        throughputFromSourceNode UInt64,
+        throughputFromDestinationNode UInt64,
+        clusterUUID String
+    ) ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
+    ORDER BY (
+        timeInserted,
+        flowEndSeconds,
+        flowEndSecondsFromSourceNode,
+        flowEndSecondsFromDestinationNode,
+        sourcePodName,
+        destinationPodName,
+        destinationIP,
+        destinationServicePort,
+        destinationServicePortName,
+        flowType,
+        sourcePodNamespace,
+        destinationPodNamespace,
+        sourceTransportPort,
+        destinationTransportPort,
+        clusterUUID);
+
+    CREATE TABLE IF NOT EXISTS node_view_table_local (
+        timeInserted DateTime DEFAULT now(),
+        flowEndSeconds DateTime,
+        flowEndSecondsFromSourceNode DateTime,
+        flowEndSecondsFromDestinationNode DateTime,
+        sourceNodeName String,
+        destinationNodeName String,
+        sourcePodNamespace String,
+        destinationPodNamespace String,
+        octetDeltaCount UInt64,
+        reverseOctetDeltaCount UInt64,
+        throughput UInt64,
+        reverseThroughput UInt64,
+        throughputFromSourceNode UInt64,
+        reverseThroughputFromSourceNode UInt64,
+        throughputFromDestinationNode UInt64,
+        reverseThroughputFromDestinationNode UInt64,
+        clusterUUID String
+    ) ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
+    ORDER BY (
+        timeInserted,
+        flowEndSeconds,
+        flowEndSecondsFromSourceNode,
+        flowEndSecondsFromDestinationNode,
+        sourceNodeName,
+        destinationNodeName,
+        sourcePodNamespace,
+        destinationPodNamespace,
+        clusterUUID);
+
+    CREATE TABLE IF NOT EXISTS policy_view_table_local (
+        timeInserted DateTime DEFAULT now(),
+        flowEndSeconds DateTime,
+        flowEndSecondsFromSourceNode DateTime,
+        flowEndSecondsFromDestinationNode DateTime,
+        egressNetworkPolicyName String,
+        egressNetworkPolicyNamespace String,
+        egressNetworkPolicyRuleAction UInt8,
+        ingressNetworkPolicyName String,
+        ingressNetworkPolicyNamespace String,
+        ingressNetworkPolicyRuleAction UInt8,
+        sourcePodName String,
+        sourceTransportPort UInt16,
+        sourcePodNamespace String,
+        destinationPodName String,
+        destinationTransportPort UInt16,
+        destinationPodNamespace String,
+        destinationServicePort UInt16,
+        destinationServicePortName String,
+        destinationIP String,
+        octetDeltaCount UInt64,
+        reverseOctetDeltaCount UInt64,
+        throughput UInt64,
+        reverseThroughput UInt64,
+        throughputFromSourceNode UInt64,
+        reverseThroughputFromSourceNode UInt64,
+        throughputFromDestinationNode UInt64,
+        reverseThroughputFromDestinationNode UInt64,
+        clusterUUID String
+    ) ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
+    ORDER BY (
+        timeInserted,
+        flowEndSeconds,
+        flowEndSecondsFromSourceNode,
+        flowEndSecondsFromDestinationNode,
+        egressNetworkPolicyName,
+        egressNetworkPolicyNamespace,
+        egressNetworkPolicyRuleAction,
+        ingressNetworkPolicyName,
+        ingressNetworkPolicyNamespace,
+        ingressNetworkPolicyRuleAction,
+        sourcePodName,
+        sourceTransportPort,
+        sourcePodNamespace,
+        destinationPodName,
+        destinationTransportPort,
+        destinationPodNamespace,
+        destinationServicePort,
+        destinationServicePortName,
+        destinationIP,
+        clusterUUID);
+
+    --Move data from old mv underlying tables and drop old mvs
+    INSERT INTO pod_view_table_local SELECT * FROM ".inner.flows_pod_view_local";
+    INSERT INTO node_view_table_local SELECT * FROM ".inner.flows_node_view_local";
+    INSERT INTO policy_view_table_local SELECT * FROM ".inner.flows_policy_view_local";
+
+    DROP VIEW flows_pod_view_local;
+    DROP VIEW flows_node_view_local;
+    DROP VIEW flows_policy_view_local;
   create_table.sh: |
     #!/usr/bin/env bash
 
@@ -467,9 +792,31 @@ data:
         ALTER TABLE flows_local MODIFY TTL timeInserted + INTERVAL 12 HOUR;
         ALTER TABLE flows_local MODIFY SETTING merge_with_ttl_timeout=14400;
 
-        --Create a Materialized View to aggregate data for pods
-        CREATE MATERIALIZED VIEW IF NOT EXISTS flows_pod_view_local
-        ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
+        --Create a Materialized View to aggregate data for Pods and save the data
+        --to default.pod_view_table_local
+        CREATE TABLE IF NOT EXISTS pod_view_table_local (
+            timeInserted DateTime DEFAULT now(),
+            flowEndSeconds DateTime,
+            flowEndSecondsFromSourceNode DateTime,
+            flowEndSecondsFromDestinationNode DateTime,
+            sourcePodName String,
+            destinationPodName String,
+            destinationIP String,
+            destinationServicePort UInt16,
+            destinationServicePortName String,
+            flowType UInt8,
+            sourcePodNamespace String,
+            destinationPodNamespace String,
+            sourceTransportPort UInt16,
+            destinationTransportPort UInt16,
+            octetDeltaCount UInt64,
+            reverseOctetDeltaCount UInt64,
+            throughput UInt64,
+            reverseThroughput UInt64,
+            throughputFromSourceNode UInt64,
+            throughputFromDestinationNode UInt64,
+            clusterUUID String
+        ) ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
         ORDER BY (
             timeInserted,
             flowEndSeconds,
@@ -485,8 +832,12 @@ data:
             destinationPodNamespace,
             sourceTransportPort,
             destinationTransportPort,
-            clusterUUID)
-        POPULATE
+            clusterUUID);
+
+        ALTER TABLE "pod_view_table_local" MODIFY TTL timeInserted + INTERVAL 12 HOUR;
+        ALTER TABLE "pod_view_table_local" MODIFY SETTING merge_with_ttl_timeout=14400;
+
+        CREATE MATERIALIZED VIEW IF NOT EXISTS flows_pod_view_local TO pod_view_table_local
         AS SELECT
             timeInserted,
             flowEndSeconds,
@@ -527,12 +878,27 @@ data:
             destinationTransportPort,
             clusterUUID;
 
-        ALTER TABLE ".inner.flows_pod_view_local" MODIFY TTL timeInserted + INTERVAL 12 HOUR;
-        ALTER TABLE ".inner.flows_pod_view_local" MODIFY SETTING merge_with_ttl_timeout=14400;
-
-        --Create a Materialized View to aggregate data for nodes
-        CREATE MATERIALIZED VIEW IF NOT EXISTS flows_node_view_local
-        ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
+        --Create a Materialized View to aggregate data for Nodes and save the data
+        --to default.node_view_table_local
+        CREATE TABLE IF NOT EXISTS node_view_table_local (
+            timeInserted DateTime DEFAULT now(),
+            flowEndSeconds DateTime,
+            flowEndSecondsFromSourceNode DateTime,
+            flowEndSecondsFromDestinationNode DateTime,
+            sourceNodeName String,
+            destinationNodeName String,
+            sourcePodNamespace String,
+            destinationPodNamespace String,
+            octetDeltaCount UInt64,
+            reverseOctetDeltaCount UInt64,
+            throughput UInt64,
+            reverseThroughput UInt64,
+            throughputFromSourceNode UInt64,
+            reverseThroughputFromSourceNode UInt64,
+            throughputFromDestinationNode UInt64,
+            reverseThroughputFromDestinationNode UInt64,
+            clusterUUID String
+        ) ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
         ORDER BY (
             timeInserted,
             flowEndSeconds,
@@ -542,8 +908,12 @@ data:
             destinationNodeName,
             sourcePodNamespace,
             destinationPodNamespace,
-            clusterUUID)
-        POPULATE
+            clusterUUID);
+
+        ALTER TABLE "node_view_table_local" MODIFY TTL timeInserted + INTERVAL 12 HOUR;
+        ALTER TABLE "node_view_table_local" MODIFY SETTING merge_with_ttl_timeout=14400;
+
+        CREATE MATERIALIZED VIEW IF NOT EXISTS flows_node_view_local TO node_view_table_local
         AS SELECT
             timeInserted,
             flowEndSeconds,
@@ -553,75 +923,6 @@ data:
             destinationNodeName,
             sourcePodNamespace,
             destinationPodNamespace,
-            sum(octetDeltaCount) AS octetDeltaCount,
-            sum(reverseOctetDeltaCount) AS reverseOctetDeltaCount,
-            sum(throughput) AS throughput,
-            sum(reverseThroughput) AS reverseThroughput,
-            sum(throughputFromSourceNode) AS throughputFromSourceNode,
-            sum(reverseThroughputFromSourceNode) AS reverseThroughputFromSourceNode,
-            sum(throughputFromDestinationNode) AS throughputFromDestinationNode,
-            sum(reverseThroughputFromDestinationNode) AS reverseThroughputFromDestinationNode,
-            clusterUUID
-        FROM flows_local
-        GROUP BY
-            timeInserted,
-            flowEndSeconds,
-            flowEndSecondsFromSourceNode,
-            flowEndSecondsFromDestinationNode,
-            sourceNodeName,
-            destinationNodeName,
-            sourcePodNamespace,
-            destinationPodNamespace,
-            clusterUUID;
-
-        ALTER TABLE ".inner.flows_node_view_local" MODIFY TTL timeInserted + INTERVAL 12 HOUR;
-        ALTER TABLE ".inner.flows_node_view_local" MODIFY SETTING merge_with_ttl_timeout=14400;
-
-        --Create a Materialized View to aggregate data for network policies
-        CREATE MATERIALIZED VIEW IF NOT EXISTS flows_policy_view_local
-        ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
-        ORDER BY (
-            timeInserted,
-            flowEndSeconds,
-            flowEndSecondsFromSourceNode,
-            flowEndSecondsFromDestinationNode,
-            egressNetworkPolicyName,
-            egressNetworkPolicyNamespace,
-            egressNetworkPolicyRuleAction,
-            ingressNetworkPolicyName,
-            ingressNetworkPolicyNamespace,
-            ingressNetworkPolicyRuleAction,
-            sourcePodName,
-            sourceTransportPort,
-            sourcePodNamespace,
-            destinationPodName,
-            destinationTransportPort,
-            destinationPodNamespace,
-            destinationServicePort,
-            destinationServicePortName,
-            destinationIP,
-            clusterUUID)
-        POPULATE
-        AS SELECT
-            timeInserted,
-            flowEndSeconds,
-            flowEndSecondsFromSourceNode,
-            flowEndSecondsFromDestinationNode,
-            egressNetworkPolicyName,
-            egressNetworkPolicyNamespace,
-            egressNetworkPolicyRuleAction,
-            ingressNetworkPolicyName,
-            ingressNetworkPolicyNamespace,
-            ingressNetworkPolicyRuleAction,
-            sourcePodName,
-            sourceTransportPort,
-            sourcePodNamespace,
-            destinationPodName,
-            destinationTransportPort,
-            destinationPodNamespace,
-            destinationServicePort,
-            destinationServicePortName,
-            destinationIP,
             sum(octetDeltaCount) AS octetDeltaCount,
             sum(reverseOctetDeltaCount) AS reverseOctetDeltaCount,
             sum(throughput) AS throughput,
@@ -637,6 +938,105 @@ data:
             flowEndSeconds,
             flowEndSecondsFromSourceNode,
             flowEndSecondsFromDestinationNode,
+            sourceNodeName,
+            destinationNodeName,
+            sourcePodNamespace,
+            destinationPodNamespace,
+            clusterUUID;
+
+        --Create a Materialized View to aggregate data for network policies and
+        --save the data to default.policy_view_table_local
+        CREATE TABLE IF NOT EXISTS policy_view_table_local (
+            timeInserted DateTime DEFAULT now(),
+            flowEndSeconds DateTime,
+            flowEndSecondsFromSourceNode DateTime,
+            flowEndSecondsFromDestinationNode DateTime,
+            egressNetworkPolicyName String,
+            egressNetworkPolicyNamespace String,
+            egressNetworkPolicyRuleAction UInt8,
+            ingressNetworkPolicyName String,
+            ingressNetworkPolicyNamespace String,
+            ingressNetworkPolicyRuleAction UInt8,
+            sourcePodName String,
+            sourceTransportPort UInt16,
+            sourcePodNamespace String,
+            destinationPodName String,
+            destinationTransportPort UInt16,
+            destinationPodNamespace String,
+            destinationServicePort UInt16,
+            destinationServicePortName String,
+            destinationIP String,
+            octetDeltaCount UInt64,
+            reverseOctetDeltaCount UInt64,
+            throughput UInt64,
+            reverseThroughput UInt64,
+            throughputFromSourceNode UInt64,
+            reverseThroughputFromSourceNode UInt64,
+            throughputFromDestinationNode UInt64,
+            reverseThroughputFromDestinationNode UInt64,
+            clusterUUID String
+        ) ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')
+        ORDER BY (
+            timeInserted,
+            flowEndSeconds,
+            flowEndSecondsFromSourceNode,
+            flowEndSecondsFromDestinationNode,
+            egressNetworkPolicyName,
+            egressNetworkPolicyNamespace,
+            egressNetworkPolicyRuleAction,
+            ingressNetworkPolicyName,
+            ingressNetworkPolicyNamespace,
+            ingressNetworkPolicyRuleAction,
+            sourcePodName,
+            sourceTransportPort,
+            sourcePodNamespace,
+            destinationPodName,
+            destinationTransportPort,
+            destinationPodNamespace,
+            destinationServicePort,
+            destinationServicePortName,
+            destinationIP,
+            clusterUUID);
+
+        ALTER TABLE "policy_view_table_local" MODIFY TTL timeInserted + INTERVAL 12 HOUR;
+        ALTER TABLE "policy_view_table_local" MODIFY SETTING merge_with_ttl_timeout=14400;
+
+        CREATE MATERIALIZED VIEW IF NOT EXISTS flows_policy_view_local to policy_view_table_local
+        AS SELECT
+            timeInserted,
+            flowEndSeconds,
+            flowEndSecondsFromSourceNode,
+            flowEndSecondsFromDestinationNode,
+            egressNetworkPolicyName,
+            egressNetworkPolicyNamespace,
+            egressNetworkPolicyRuleAction,
+            ingressNetworkPolicyName,
+            ingressNetworkPolicyNamespace,
+            ingressNetworkPolicyRuleAction,
+            sourcePodName,
+            sourceTransportPort,
+            sourcePodNamespace,
+            destinationPodName,
+            destinationTransportPort,
+            destinationPodNamespace,
+            destinationServicePort,
+            destinationServicePortName,
+            destinationIP,
+            sum(octetDeltaCount) AS octetDeltaCount,
+            sum(reverseOctetDeltaCount) AS reverseOctetDeltaCount,
+            sum(throughput) AS throughput,
+            sum(reverseThroughput) AS reverseThroughput,
+            sum(throughputFromSourceNode) AS throughputFromSourceNode,
+            sum(reverseThroughputFromSourceNode) AS reverseThroughputFromSourceNode,
+            sum(throughputFromDestinationNode) AS throughputFromDestinationNode,
+            sum(reverseThroughputFromDestinationNode) AS reverseThroughputFromDestinationNode,
+            clusterUUID
+        FROM flows_local
+        GROUP BY
+            timeInserted,
+            flowEndSeconds,
+            flowEndSecondsFromSourceNode,
+            flowEndSecondsFromDestinationNode,
             egressNetworkPolicyName,
             egressNetworkPolicyNamespace,
             egressNetworkPolicyRuleAction,
@@ -653,9 +1053,6 @@ data:
             destinationServicePortName,
             destinationIP,
             clusterUUID;
-
-        ALTER TABLE ".inner.flows_policy_view_local" MODIFY TTL timeInserted + INTERVAL 12 HOUR;
-        ALTER TABLE ".inner.flows_policy_view_local" MODIFY SETTING merge_with_ttl_timeout=14400;
 
         --Create a table to store the network policy recommendation results
         CREATE TABLE IF NOT EXISTS recommendations_local (
@@ -6815,7 +7212,7 @@ spec:
           - name: TABLE_NAME
             value: default.flows_local
           - name: MV_NAMES
-            value: default.flows_pod_view_local default.flows_node_view_local default.flows_policy_view_local
+            value: default.pod_view_table_local default.node_view_table_local default.policy_view_table_local
           - name: STORAGE_SIZE
             value: 8Gi
           - name: THRESHOLD
@@ -6852,6 +7249,10 @@ spec:
               path: migrators/000004_0-4-0.down.sql
             - key: 000004_0-4-0.up.sql
               path: migrators/000004_0-4-0.up.sql
+            - key: 000005_0-6-0.down.sql
+              path: migrators/000005_0-6-0.down.sql
+            - key: 000005_0-6-0.up.sql
+              path: migrators/000005_0-6-0.up.sql
             name: clickhouse-mounted-configmap
           name: clickhouse-configmap-volume
         - emptyDir:

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -394,8 +394,8 @@ function deliver_antrea {
         ssh-keygen -f "/var/lib/jenkins/.ssh/known_hosts" -R ${IPs[$i]}
         copy_image antrea-ubuntu.tar docker.io/antrea/antrea-ubuntu ${IPs[$i]} latest true
         copy_image flow-aggregator.tar docker.io/antrea/flow-aggregator ${IPs[$i]} latest  true
-        copy_image theia-clickhouse-operator.tar projects.registry.vmware.com/antrea/theia-clickhouse-operator  ${IPs[$i]} $image_tag true
-        copy_image theia-metrics-exporter.tar projects.registry.vmware.com/antrea/theia-metrics-exporter  ${IPs[$i]} $image_tag true
+        copy_image clickhouse-operator.tar projects.registry.vmware.com/antrea/clickhouse-operator  ${IPs[$i]} $image_tag true
+        copy_image metrics-exporter.tar projects.registry.vmware.com/antrea/metrics-exporter  ${IPs[$i]} $image_tag true
         copy_image theia-zookeeper.tar projects.registry.vmware.com/antrea/theia-zookeeper  ${IPs[$i]} 3.8.0 true
         copy_image theia-spark-operator.tar projects.registry.vmware.com/antrea/theia-spark-operator ${IPs[$i]} v1beta2-1.3.3-3.1.1 true
         copy_image theia-spark-jobs.tar projects.registry.vmware.com/antrea/theia-spark-jobs ${IPs[$i]} latest true

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -109,8 +109,8 @@ COMMON_IMAGES_LIST=("registry.k8s.io/e2e-test-images/agnhost:2.29" \
                     "projects.registry.vmware.com/antrea/perftool" \
                     "antrea/antrea-ubuntu:latest" \
                     "antrea/flow-aggregator:latest" \
-                    "projects.registry.vmware.com/antrea/theia-clickhouse-operator:0.18.2" \
-                    "projects.registry.vmware.com/antrea/theia-metrics-exporter:0.18.2" \
+                    "projects.registry.vmware.com/antrea/clickhouse-operator:0.21.0" \
+                    "projects.registry.vmware.com/antrea/metrics-exporter:0.21.0" \
                     "projects.registry.vmware.com/antrea/theia-zookeeper:3.8.0" \
                     "projects.registry.vmware.com/antrea/theia-grafana:8.3.3" \
                     "projects.registry.vmware.com/antrea/theia-spark-operator:v1beta2-1.3.3-3.1.1")

--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -88,9 +88,11 @@ not to clone the repository, you can mannually deploy it. The first step is to
 install the ClickHouse Operator, which creates, configures and manages ClickHouse
 clusters. Check the [homepage](https://github.com/Altinity/clickhouse-operator)
 for more information about the ClickHouse Operator. Current checked-in yaml is
-based on their [v0.18.2](https://github.com/Altinity/clickhouse-operator/blob/refs/tags/0.18.2/deploy/operator/clickhouse-operator-install-bundle.yaml)
+based on their [v0.21.0](https://github.com/Altinity/clickhouse-operator/blob/release-0.21.0/deploy/operator/clickhouse-operator-install-bundle.yaml)
 released version. Running the following command will install ClickHouse Operator
-into `kube-system` Namespace.
+into `kube-system` Namespace. Note that we upgrade ClickHouse Operator to
+v0.21.0 starting from Theia 0.7. Please make sure to deploy the latest ClickHouse
+Operator if you would like to try Theia 0.7.
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/antrea-io/theia/main/build/charts/theia/crds/clickhouse-operator-install-bundle.yaml

--- a/pkg/util/clickhouse/clickhouse.go
+++ b/pkg/util/clickhouse/clickhouse.go
@@ -39,8 +39,8 @@ const (
 	ServicePortProtocal = "TCP"
 	// #nosec G101: false positive triggered by variable name which includes "secret"
 	SecretName = "clickhouse-secret"
-	// Ping to ClickHouse time out if it fails for 10 seconds.
-	pingTimeout = 10 * time.Second
+	// Ping to ClickHouse time out if it fails for 30 seconds.
+	pingTimeout = 30 * time.Second
 	// Retry ping to ClickHouse every second if it fails.
 	pingRetryInterval = 1 * time.Second
 )

--- a/pkg/util/clickhouse/clickhouse_test.go
+++ b/pkg/util/clickhouse/clickhouse_test.go
@@ -106,7 +106,7 @@ func TestSetupConnection(t *testing.T) {
 				os.Unsetenv(passwordKey)
 				os.Unsetenv(urlKey)
 			},
-			expectedErrorMsg: "failed to connect to ClickHouse after 10s, error list: [\nerror message: first error,\nsecond error,\n",
+			expectedErrorMsg: fmt.Sprintf("failed to connect to ClickHouse after %ds, error list: [\nerror message: first error,\nsecond error,\n", int(pingTimeout.Seconds())),
 		},
 	}
 

--- a/test/e2e/flowvisibility_test.go
+++ b/test/e2e/flowvisibility_test.go
@@ -664,9 +664,9 @@ func checkClickHouseMonitorLogs(t *testing.T, data *TestData, deleted bool, numR
 		assert.Greater(t, percentage, monitorThreshold)
 		// Monitor deletes records from table flows and related MVs
 		assert.Contains(t, logString, "ALTER TABLE default.flows_local DELETE WHERE timeInserted < toDateTime", "Monitor should delete records from Table flows")
-		assert.Contains(t, logString, "ALTER TABLE default.flows_pod_view_local DELETE WHERE timeInserted < toDateTime", "Monitor should delete records from View flows_pod_view")
-		assert.Contains(t, logString, "ALTER TABLE default.flows_node_view_local DELETE WHERE timeInserted < toDateTime", "Monitor should delete records from View flows_node_view")
-		assert.Contains(t, logString, "ALTER TABLE default.flows_policy_view_local DELETE WHERE timeInserted < toDateTime", "Monitor should delete records from View flows_policy_view")
+		assert.Contains(t, logString, "ALTER TABLE default.pod_view_table_local DELETE WHERE timeInserted < toDateTime", "Monitor should delete records from View flows_pod_view")
+		assert.Contains(t, logString, "ALTER TABLE default.node_view_table_local DELETE WHERE timeInserted < toDateTime", "Monitor should delete records from View flows_node_view")
+		assert.Contains(t, logString, "ALTER TABLE default.policy_view_table_local DELETE WHERE timeInserted < toDateTime", "Monitor should delete records from View flows_policy_view")
 		assert.Contains(t, logString, "Skip rounds after a successful deletion", "Monitor should skip rounds after a successful deletion")
 		require.Contains(t, logString, "[send query] SELECT timeInserted FROM default.flows_local LIMIT 1 OFFSET (", "Monitor should log the deletion SQL command")
 		deletedRecordLog := strings.Split(logString, "[send query] SELECT timeInserted FROM default.flows_local LIMIT 1 OFFSET (")[1]

--- a/test/e2e/theia_clickhouse_test.go
+++ b/test/e2e/theia_clickhouse_test.go
@@ -121,12 +121,13 @@ func testTheiaGetClickHouseDiskInfo(t *testing.T, data *TestData) {
 }
 
 // Example output
-// Shard          DatabaseName   TableName                TotalRows      TotalBytes     TotalCols
-// 1              default        .inner.flows_node_view   50000          4.19 MiB       16
-// 1              default        .inner.flows_pod_view    48000          4.72 MiB       20
-// 1              default        .inner.flows_policy_view 48000          7.16 MiB       27
-// 1              default        flows                    50000          13.09 MiB      49
-// 1              default        recommendations          10             2.34 KiB       4
+// Shard          DatabaseName   TableName               TotalRows      TotalBytes     TotalCols
+// 1              default        flows_local             780            40.33 KiB      50
+// 1              default        node_view_table_local   29             5.56 KiB       17
+// 1              default        pod_view_table_local    392            14.41 KiB      21
+// 1              default        policy_view_table_local 392            19.07 KiB      28
+// 1              default        recommendations_local   0              0.00 B         5
+// 1              default        tadetector_local        0              0.00 B         13
 func testTheiaGetClickHouseTableInfo(t *testing.T, data *TestData, connect *sql.DB) {
 	// send 1000 records to clickhouse
 	commitNum := 1
@@ -152,11 +153,12 @@ func testTheiaGetClickHouseTableInfo(t *testing.T, data *TestData, connect *sql.
 	assert.Containsf(stdout, "TotalBytes", "stdout: %s", stdout)
 	assert.Containsf(stdout, "TotalCols", "stdout: %s", stdout)
 	// check four tables are in db
-	assert.Containsf(stdout, ".inner.flows_node_view_local", "stdout: %s", stdout)
-	assert.Containsf(stdout, ".inner.flows_pod_view_local", "stdout: %s", stdout)
-	assert.Containsf(stdout, ".inner.flows_policy_view_local", "stdout: %s", stdout)
+	assert.Containsf(stdout, "node_view_table_local", "stdout: %s", stdout)
+	assert.Containsf(stdout, "pod_view_table_local", "stdout: %s", stdout)
+	assert.Containsf(stdout, "policy_view_table_local", "stdout: %s", stdout)
 	assert.Containsf(stdout, "flows_local", "stdout: %s", stdout)
 	assert.Containsf(stdout, "recommendations_local", "stdout: %s", stdout)
+	assert.Containsf(stdout, "tadetector_local", "stdout: %s", stdout)
 
 	flowNum := 0
 	for i := 1; i < length; i++ {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -498,7 +498,7 @@ func TheiaManagerRestart(t *testing.T, data *TestData, jobName1 string, job stri
 	}
 
 	// Redeploy the Theia Manager
-	err = data.deployFlowVisibilityCommon(flowVisibilityWithSparkYML)
+	err = data.deployFlowVisibilityCommon(clickHouseOperatorYML, flowVisibilityWithSparkYML)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Upgrade ClickHouse server to v23.4
- Upgrade ClickHouse operator and metrics exporter to v0.21.0

Notable changes:
- The inner table name of Materialized View has
been changed to `.inner_id.<uuid>`. We are no longer able to
find the table by self-defined Materialized View name. Thus,
in `create_table.sh`, we save the data of Materialized Views
to pre-defined underlying tables.
- ClickHouse upgrade test used to always apply the latest
clickhouse-operator-install-bundle.yaml. In this upgrade,
latest operator yaml does not work with version N-1 ClickHouse
data schema. Therefore, we change the test to use the correct
version of operator yaml corresponding to the tested ClickHouse
data schema.
- We removed the theia- prefix in clickhouse operator images in
- We increased theia-manager ping timeout when connecting to
ClickHouse Service to fix test flakiness.
- We added a time wait before starting iPerf traffic in e2e test to
avoid missing the first a few records.

Signed-off-by: heanlan <hanlan@vmware.com>