### PR TITLE
Fixing upgrade N-1 error

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -115,6 +115,7 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo rm -rf "/usr/local/lib/android"
+          docker system prune -a -f --filter "until=1h" || true > /dev/null
           df -h
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -146,6 +147,12 @@ jobs:
           docker tag antrea/theia-clickhouse-server:latest projects.registry.vmware.com/antrea/theia-clickhouse-server:latest
           docker load -i theia-manager.tar
           docker tag antrea/theia-manager:latest projects.registry.vmware.com/antrea/theia-manager:latest
+      - name: Remove Theia images tar files
+        run:  |
+          rm -rf clickhouse-server.tar
+          rm -rf clickhouse-monitor.tar
+          rm -rf spark-jobs.tar
+          rm -rf theia-manager.tar
       - name: Install Kind
         run: |
           curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
@@ -177,8 +184,10 @@ jobs:
   test-upgrade-from-N-1:
     name: Upgrade from Theia version N-1
     needs: 
+      - build-spark-jobs-image
       - build-clickhouse-monitor-image
-      - build-clickhouse-server-image 
+      - build-clickhouse-server-image
+      - build-theia-manager-image
     runs-on: [ubuntu-latest]
     steps:
       - name: Free disk space
@@ -190,27 +199,47 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo rm -rf "/usr/local/lib/android"
+          sudo apt-get autoremove
+          sudo apt-get clean
+          sudo apt-get autoclean
+          docker system prune -a -f --filter "until=1h" || true > /dev/null
           df -h
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+      - name: Download Spark jobs images from previous jobs
+        uses: actions/download-artifact@v3
+        with:
+          name: spark-jobs
       - name: Download ClickHouse monitor images from previous jobs
         uses: actions/download-artifact@v3
         with:
           name: clickhouse-monitor
-      - name: Load Theia image
-        run:  |
-          docker load -i clickhouse-monitor.tar
-          docker tag antrea/theia-clickhouse-monitor:latest projects.registry.vmware.com/antrea/theia-clickhouse-monitor:latest
       - name: Download ClickHouse server images from previous jobs
         uses: actions/download-artifact@v3
         with:
           name: clickhouse-server
+      - name: Download Theia Manager images from previous jobs
+        uses: actions/download-artifact@v3
+        with:
+          name: theia-manager
       - name: Load Theia image
         run:  |
+          docker load -i spark-jobs.tar
+          docker tag antrea/theia-spark-jobs:latest projects.registry.vmware.com/antrea/theia-spark-jobs:latest
+          docker load -i clickhouse-monitor.tar
+          docker tag antrea/theia-clickhouse-monitor:latest projects.registry.vmware.com/antrea/theia-clickhouse-monitor:latest
           docker load -i clickhouse-server.tar
           docker tag antrea/theia-clickhouse-server:latest projects.registry.vmware.com/antrea/theia-clickhouse-server:latest
+          docker load -i theia-manager.tar
+          docker tag antrea/theia-manager:latest projects.registry.vmware.com/antrea/theia-manager:latest
+      - name: Remove Theia images tar files
+        run:  |
+          rm -rf clickhouse-server.tar
+          rm -rf clickhouse-monitor.tar
+          rm -rf spark-jobs.tar
+          rm -rf theia-manager.tar
       - name: Install Kind
         run: |
           curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
@@ -247,6 +276,9 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo rm -rf "/usr/local/lib/android"
+          sudo apt-get autoremove
+          sudo apt-get autoclean
+          docker system prune -a -f --filter "until=1h" || true > /dev/null
           df -h
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -256,18 +288,20 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: clickhouse-monitor
-      - name: Load Theia image
-        run:  |
-          docker load -i clickhouse-monitor.tar
-          docker tag antrea/theia-clickhouse-monitor:latest projects.registry.vmware.com/antrea/theia-clickhouse-monitor:latest
       - name: Download ClickHouse server images from previous jobs
         uses: actions/download-artifact@v3
         with:
           name: clickhouse-server
-      - name: Load Theia image
+      - name: Load Theia clickhouse images
         run:  |
+          docker load -i clickhouse-monitor.tar
+          docker tag antrea/theia-clickhouse-monitor:latest projects.registry.vmware.com/antrea/theia-clickhouse-monitor:latest
           docker load -i clickhouse-server.tar
           docker tag antrea/theia-clickhouse-server:latest projects.registry.vmware.com/antrea/theia-clickhouse-server:latest
+      - name: Remove Theia images tar files
+        run:  |
+          rm -rf clickhouse-server.tar
+          rm -rf clickhouse-monitor.tar
       - name: Install Kind
         run: |
           curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64

--- a/build/images/Dockerfile.spark-jobs.ubuntu
+++ b/build/images/Dockerfile.spark-jobs.ubuntu
@@ -1,4 +1,4 @@
-FROM apache/spark-py:v3.4.0
+FROM spark:python3
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A docker image to deploy policy recommendation and throughput anomaly detection Spark job."
@@ -9,6 +9,10 @@ USER root
 RUN apt-get --allow-releaseinfo-change update && \
     apt-get install -y --no-install-recommends wget ca-certificates && \
     wget https://github.com/ClickHouse/clickhouse-jdbc/releases/download/v0.3.1/clickhouse-jdbc-0.3.1.jar -P /opt/spark/jars/
+    
+RUN rm -rf /var/cache/apt/* /var/lib/apt/lists/* && \
+    rm -rf /tmp/* && \
+    apt-get clean
 
 COPY plugins/policy-recommendation/policy_recommendation_job.py /opt/spark/work-dir/policy_recommendation_job.py
 COPY plugins/policy-recommendation/policy_recommendation_utils.py /opt/spark/work-dir/policy_recommendation_utils.py
@@ -16,7 +20,6 @@ COPY plugins/policy-recommendation/antrea_crd.py /opt/spark/work-dir/antrea_crd.
 COPY plugins/anomaly-detection/anomaly_detection.py /opt/spark/work-dir/anomaly_detection.py
 COPY plugins/anomaly-detection/requirements.txt /opt/spark/work-dir/anomaly_detection_requirements.txt
 
-RUN pip3 install --upgrade pip && \
-    pip3 install pyyaml && \
-    pip3 install kubernetes && \
-    pip3 install -r /opt/spark/work-dir/anomaly_detection_requirements.txt
+RUN pip3 install --upgrade pip --no-cache-dir && \
+    pip3 install kubernetes --no-cache-dir && \
+    pip3 install -r /opt/spark/work-dir/anomaly_detection_requirements.txt --no-cache-dir

--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -206,6 +206,7 @@ function load_images {
       continue
     fi
     echo "loaded image $img"
+    rm -rf $img
   done
   set -e
 }

--- a/ci/kind/test-upgrade-theia.sh
+++ b/ci/kind/test-upgrade-theia.sh
@@ -189,7 +189,9 @@ DOCKER_IMAGES=("registry.k8s.io/e2e-test-images/agnhost:2.29" \
                 "projects.registry.vmware.com/antrea/antrea-ubuntu:$ANTREA_FROM_TAG" \
                 "projects.registry.vmware.com/antrea/theia-clickhouse-monitor:$THEIA_FROM_TAG" \
                 "projects.registry.vmware.com/antrea/theia-clickhouse-server:$CLICKHOUSE_FROM_TAG" \
+                "projects.registry.vmware.com/antrea/theia-manager:$THEIA_FROM_TAG" \
                 "antrea/antrea-ubuntu:latest")
+
 
 for img in "${DOCKER_IMAGES[@]}"; do
     echo "Pulling $img"
@@ -200,7 +202,9 @@ for img in "${DOCKER_IMAGES[@]}"; do
 done
 
 DOCKER_IMAGES+=("projects.registry.vmware.com/antrea/theia-clickhouse-monitor:latest\
-                 projects.registry.vmware.com/antrea/theia-clickhouse-server:latest")
+                 projects.registry.vmware.com/antrea/theia-clickhouse-server:latest\
+                 projects.registry.vmware.com/antrea/theia-manager:latest\
+                 projects.registry.vmware.com/antrea/theia-spark-jobs:latest")
 
 echo "Creating Kind cluster"
 IMAGES="${DOCKER_IMAGES[@]}"


### PR DESCRIPTION
The issue with N-1 upgrade failing was due to lack of loading of required images and removal of stale images and acquired disk space by resources not required anymore after a certain task is over.
This PR helps get some extra disk space and also decrease the size of the spark-jobs image by 300 mb in compressed image size.