### PR TITLE
Fix Policy Recommendation E2E test in Kind Cluster

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -185,9 +185,9 @@ function run_test {
   sleep 1
 
   if $coverage; then
-    go test -v -timeout=30m antrea.io/theia/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR -cover -covermode=atomic --skip=$skiplist
+    go test -v -timeout=45m antrea.io/theia/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR -cover -covermode=atomic --skip=$skiplist
   else
-    go test -v -timeout=30m antrea.io/theia/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR --skip=$skiplist
+    go test -v -timeout=45m antrea.io/theia/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR --skip=$skiplist
   fi
 
 }


### PR DESCRIPTION
Kind cluster introduced a new Pod local-path-provisioner recently which
causes Policy Recommendation E2E test because of recomming extra Network
Policies.
To fix test, we add the new Pod's namespace local-path-storage
into the argument when starting the recommendation job in Kind cluster.