### PR TITLE
Add AdHoc Filters to Snowflake Dashboards

### DIFF
--- a/snowflake/grafana/provisioning/dashboards/flows_records_dashboard.json
+++ b/snowflake/grafana/provisioning/dashboards/flows_records_dashboard.json
@@ -1093,6 +1093,24 @@
                 "skipUrlSync": false,
                 "sort": 0,
                 "type": "query"
+            },
+            {
+                "datasource": {
+                  "type": "michelin-snowflake-datasource",
+                  "uid": "P1DBD59F661D68B90"
+                },
+                "filters": [],
+                "hide": 0,
+                "name": "Filter",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "hide": 2,
+                "name": "snowflake_adhoc_query",
+                "query": "select * from flows",
+                "skipUrlSync": false,
+                "type": "constant"
             }
         ]
     },

--- a/snowflake/grafana/provisioning/dashboards/networkpolicy_dashboard.json
+++ b/snowflake/grafana/provisioning/dashboards/networkpolicy_dashboard.json
@@ -751,6 +751,24 @@
                 "skipUrlSync": false,
                 "sort": 0,
                 "type": "query"
+            },
+            {
+                "datasource": {
+                  "type": "michelin-snowflake-datasource",
+                  "uid": "P1DBD59F661D68B90"
+                },
+                "filters": [],
+                "hide": 0,
+                "name": "Filter",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "hide": 2,
+                "name": "snowflake_adhoc_query",
+                "query": "select * from policies",
+                "skipUrlSync": false,
+                "type": "constant"
             }
         ]
     },

--- a/snowflake/grafana/provisioning/dashboards/pod_to_pod_dashboard.json
+++ b/snowflake/grafana/provisioning/dashboards/pod_to_pod_dashboard.json
@@ -830,6 +830,24 @@
                 "skipUrlSync": false,
                 "sort": 0,
                 "type": "query"
+            },
+            {
+                "datasource": {
+                  "type": "michelin-snowflake-datasource",
+                  "uid": "P1DBD59F661D68B90"
+                },
+                "filters": [],
+                "hide": 0,
+                "name": "Filter",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "hide": 2,
+                "name": "snowflake_adhoc_query",
+                "query": "select * from pods",
+                "skipUrlSync": false,
+                "type": "constant"
             }
         ]
     },


### PR DESCRIPTION
This PR adds the AdHoc filter and constant variable to the snowflake grafana dashboards.
[PR in the datasource repo.](https://github.com/michelin/snowflake-grafana-datasource/pull/52)

Fixes issue #160