### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4 (#455)"

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Run unit tests
       run: make test-unit
     - name: Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: .coverage/unit/coverage-unit.txt
@@ -86,7 +86,7 @@ jobs:
         cd snowflake
         make test-unit
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: snowflake/.coverage/coverage-unit.txt

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -166,7 +166,7 @@ jobs:
         if: ${{ failure() }}
         run: tar -czf log.tar.gz log
       - name: Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: .coverage/complete-kind-e2e-coverage.txt

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -114,7 +114,7 @@ jobs:
           cd plugins/anomaly-detection/
           pytest -vv --cov . --cov-report xml
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: plugins/policy-recommendation/coverage.xml,plugins/anomaly-detection/coverage.xml

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -57,7 +57,7 @@ jobs:
         yarn test --coverage
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
This reverts commit cfc7da113aabe06ae13dcccb97994ad53fbd9c4d.
Currently, codecov-action@v4 is in beta. Changing the version from v3 to v4 results in GitHub Actions being unable to locate the action codecov/codecov-action@v4, resulting in the failure of unit and end-to-end tests.

Signed-off-by: Yun-Tang Hsu <hsuy@vmware.com>
