### PR TITLE
Pre-load images when creating cluster for multi-cluster e2e test

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -217,6 +217,10 @@ jobs:
           docker tag antrea/theia-clickhouse-monitor:latest projects.registry.vmware.com/antrea/theia-clickhouse-monitor:latest
           docker load -i clickhouse-server.tar
           docker tag antrea/theia-clickhouse-server:latest projects.registry.vmware.com/antrea/theia-clickhouse-server:latest
+      - name: Remove Theia images tar files
+        run: |
+          rm -rf clickhouse-server.tar
+          rm -rf clickhouse-monitor.tar
       - name: Install Kind
         run: |
           curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64

--- a/ci/kind/test-multi-cluster.sh
+++ b/ci/kind/test-multi-cluster.sh
@@ -33,7 +33,7 @@ function print_usage {
 
 
 TESTBED_CMD=$(dirname $0)"/kind-setup.sh"
-FLOW_VISIBILITY_CH_ONLY_CMD=$(dirname $0)"/../../hack/generate-manifest.sh --no-grafana --node-port --secure-connection"
+FLOW_VISIBILITY_CH_ONLY_CMD=$(dirname $0)"/../../hack/generate-manifest.sh --ch-only --node-port --secure-connection"
 CH_OPERATOR_YML=$(dirname $0)"/../../build/charts/theia/crds/clickhouse-operator-install-bundle.yaml"
 
 WORKDIR=$HOME
@@ -98,7 +98,7 @@ function setup_multi_cluster {
 
   echo "creating test bed with args $args"
   for i in {0..1}; do
-      eval "timeout 600 $TESTBED_CMD create ${CLUSTER_NAMES[$i]} --num-workers 1"
+      eval "timeout 600 $TESTBED_CMD create ${CLUSTER_NAMES[$i]} $args --num-workers 1"
   done
 
   for name in ${CLUSTER_NAMES[*]}; do

--- a/test/e2e_mc/multicluster_test.go
+++ b/test/e2e_mc/multicluster_test.go
@@ -84,7 +84,7 @@ func TestMultiCluster(t *testing.T) {
 	t.Logf("Verifying records in ClickHouse")
 	require.GreaterOrEqualf(t, len(clickHouseRecordsW), expectedNumDataRecords, "ClickHouse should receive expected number of flow records. Considered records: %v", clickHouseRecordsW)
 	t.Logf("Verifying cluster UUID in East/West cluster are different")
-	require.NotEqualf(t, clickHouseRecordsE[0].ClusterUUID, clickHouseRecordsW[0].ClusterUUID, "ClusterUUID for EAST/WEST cluster should be different\n. Records of EAST cluster: %v\nRecords of EAST cluster: %v", clickHouseRecordsE, clickHouseRecordsW)
+	require.NotEqualf(t, clickHouseRecordsE[0].ClusterUUID, clickHouseRecordsW[0].ClusterUUID, "ClusterUUID for EAST/WEST cluster should be different.\n Records of EAST cluster: %v\nRecords of EAST cluster: %v", clickHouseRecordsE, clickHouseRecordsW)
 }
 
 func createPerftestPods(data *MCTestData) (podAIPs *e2e.PodIPs, podBIPs *e2e.PodIPs, podCIPs *e2e.PodIPs, podDIPs *e2e.PodIPs, err error) {


### PR DESCRIPTION
In this PR, we do:
1. Add --image flag when creating cluster for multi-cluster e2e test.
2. Remove Theia Manager when generating manifest for multi-cluster e2e test.

The reasons are:
1. During the creation of the multi-cluster end-to-end test, images were not preloaded, which caused an error. This error stated that the ClickHouse Pod's status couldn't become ready within the expected timeframe due to the extended duration required for pulling the images.
2. Theia Manager is not required in multi-cluster e2e test.

Signed-off-by: Yun-Tang Hsu <hsuy@vmware.com>
