### PR TITLE
Fix theia daily validation on Jenkins.

### DIFF
--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -6,7 +6,7 @@
     org_repo: antrea-io/theia
     jobs:
       - '{name}-{test_name}-for-period':
-         test_name: daily-flow-visibility-validate
+         test_name: daily-validate
          node: 'antrea-test-node'
          description: 'This is for validating the flow visibility manifest daily'
          builders:


### PR DESCRIPTION
Theia daily validation keeps failing because this error:
`Invalid value: "jenkins-theia-daily-flow-visibility-validate-for-period-132-md-0": must be no more than 63 characters`
Open this PR to rename the daily job.