### PR TITLE
Remove uninitialized taint to recover CAPV testbeds

### DIFF
--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -450,6 +450,7 @@ function run_e2e {
 
     set +e
     # HACK: see https://github.com/antrea-io/antrea/issues/2292
+    kubectl taint nodes --selector='!node-role.kubernetes.io/control-plane' node.cluster.x-k8s.io/uninitialized-
     go test -v -timeout=100m antrea.io/theia/test/e2e --logs-export-dir ${GIT_CHECKOUT_DIR}/theia-test-logs --provider remote --remote.sshconfig "${CLUSTER_SSHCONFIG}" --remote.kubeconfig "${CLUSTER_KUBECONFIG}"
 
 


### PR DESCRIPTION
The updated CAPV cluster will generate uninitialized taint on worker nodes. To avoid blocking the tests, we need to update related script.