### PR TITLE
Update nindent from 10 > 2 for ZooKeeper persistentvolumeclaim.yaml

### DIFF
--- a/build/charts/theia/templates/clickhouse/zookeeper/persistentvolumeclaim.yaml
+++ b/build/charts/theia/templates/clickhouse/zookeeper/persistentvolumeclaim.yaml
@@ -10,7 +10,7 @@ spec:
   storageClassName: zookeeper-storage
   {{- else }}
   {{- with .Values.clickhouse.cluster.installZookeeper.storage.persistentVolumeClaimSpec }}
-  {{- toYaml . | trim | nindent 10 }}
+  {{- toYaml . | trim | nindent 2 }}
   {{- end }}
   {{- end }}
   accessModes:


### PR DESCRIPTION
We were upgrading our Theia release to make use of the new Zookeeper PVC resource so as we don't keep running into the "ReadOnly" error once the clickhouse pods gets deleted / recreated.

When trying to configure this through Helm i kept getting the below error:
`Helm install failed: YAML parse error on theia/templates/clickhouse/zookeeper/persistentvolumeclaim.yaml: error converting YAML to JSON: yaml: line 8: did not find expected key`

In order to get past this error i changed the nindent value from 10 > 2, after doing so everything installs as expected.

Furthermore i have been able to validate that after upgrading and using a Zookeeper PVC the clickhouse error goes away :)

Thanks 