### PR TITLE
Automated cherry pick of #554: Update nindent from 10 > 2 for ZooKeeper persistentvolumeclaim.yaml

### DIFF
--- a/build/charts/theia/templates/clickhouse/zookeeper/persistentvolumeclaim.yaml
+++ b/build/charts/theia/templates/clickhouse/zookeeper/persistentvolumeclaim.yaml
@@ -10,7 +10,7 @@ spec:
   storageClassName: zookeeper-storage
   {{- else }}
   {{- with .Values.clickhouse.cluster.installZookeeper.storage.persistentVolumeClaimSpec }}
-  {{- toYaml . | trim | nindent 10 }}
+  {{- toYaml . | trim | nindent 2 }}
   {{- end }}
   {{- end }}
   accessModes:


### PR DESCRIPTION
Cherry pick of #554 on release-0.7.1.

#554: update nindent from 10 > 2

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.