### PR TITLE
Improve ClickHouse monitor e2e test

### DIFF
--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -338,7 +338,7 @@ function deliver_antrea {
 
     control_plane_ip="$(kubectl get nodes -o wide --no-headers=true | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 ~ role {print $6}')"
 
-    ${GIT_CHECKOUT_DIR}/hack/generate-manifest.sh --ch-size 100Mi --ch-monitor-threshold 0.1 --theia-manager > ${GIT_CHECKOUT_DIR}/build/yamls/flow-visibility.yml
+    ${GIT_CHECKOUT_DIR}/hack/generate-manifest.sh --ch-size 100Mi --ch-monitor-threshold 0.1 --ch-monitor-exec-interval 10s --theia-manager > ${GIT_CHECKOUT_DIR}/build/yamls/flow-visibility.yml
     ${GIT_CHECKOUT_DIR}/hack/generate-manifest.sh --no-grafana --spark-operator --theia-manager > ${GIT_CHECKOUT_DIR}/build/yamls/flow-visibility-with-spark.yml
     ${GIT_CHECKOUT_DIR}/hack/generate-manifest.sh --no-grafana --theia-manager > ${GIT_CHECKOUT_DIR}/build/yamls/flow-visibility-ch-only.yml
 

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -39,7 +39,7 @@ function print_usage {
 
 TESTBED_CMD=$(dirname $0)"/kind-setup.sh"
 YML_DIR=$(dirname $0)"/../../build/yamls"
-FLOW_VISIBILITY_CMD=$(dirname $0)"/../../hack/generate-manifest.sh --ch-size 100Mi --ch-monitor-threshold 0.1 --theia-manager"
+FLOW_VISIBILITY_CMD=$(dirname $0)"/../../hack/generate-manifest.sh --ch-size 100Mi --ch-monitor-threshold 0.1 --ch-monitor-exec-interval 10s --theia-manager"
 FLOW_VISIBILITY_WITH_SPARK_CMD=$(dirname $0)"/../../hack/generate-manifest.sh --no-grafana --spark-operator --theia-manager"
 FLOW_VISIBILITY_CH_ONLY_CMD=$(dirname $0)"/../../hack/generate-manifest.sh --no-grafana --theia-manager"
 CH_OPERATOR_YML=$(dirname $0)"/../../build/charts/theia/crds/clickhouse-operator-install-bundle.yaml"

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -40,6 +40,7 @@ Kustomize, and print it to stdout.
                                             Ei, Pi, Ti, Gi, Mi, Ki. (default is 8Gi)
         --ch-monitor-threshold <threshold>  Deploy the ClickHouse monitor with a specific threshold. Can
                                             vary from 0 to 1. (default is 0.5)
+        --ch-monitor-exec-interval          Deploy the ClickHouse monitor with a specific EXEC_INTERVAL.
         --local <path>                      Create the PersistentVolume for Clickhouse DB with a provided
                                             local path.
         --zookeeper-local <path>            Create the PersistentVolume for ZooKeeper with a provided
@@ -70,6 +71,7 @@ CH_THRESHOLD=0.5
 LOCALPATH=""
 ZK_LOCALPATH=""
 IP_ADDRESS=""
+EXEC_INTERVAL="1m"
 
 while [[ $# -gt 0 ]]
 do
@@ -110,6 +112,10 @@ case $key in
     ;;
     --ch-monitor-threshold)
     CH_THRESHOLD="$2"
+    shift 2
+    ;;
+    --ch-monitor-exec-interval)
+    EXEC_INTERVAL="$2"
     shift 2
     ;;
     --local)
@@ -167,7 +173,7 @@ fi
 
 HELM_VALUES=()
 
-HELM_VALUES+=("clickhouse.storage.size=$CH_SIZE" "clickhouse.monitor.threshold=$CH_THRESHOLD")
+HELM_VALUES+=("clickhouse.storage.size=$CH_SIZE" "clickhouse.monitor.threshold=$CH_THRESHOLD" "clickhouse.monitor.execInterval=$EXEC_INTERVAL")
 
 if [ "$MODE" == "dev" ] && [ -n "$IMG_NAME" ]; then
     HELM_VALUES+=("clickhouse.monitor.image.repository=$IMG_NAME")


### PR DESCRIPTION
This pull request enhances the ClickHouse monitor end-to-end test. Previously, this particular e2e test exhibited instability and was prone to frequent failures. The root cause was our previous approach, wherein we would send a large volume of traffic and then wait for 30 seconds before verifying the total number of records in ClickHouse. During this 30-second interval, the cleaning process within ClickHouse Monitor could be triggered, leading to incorrect total record counts.

To address this issue, we have made improvements by implementing the following changes:

1. We now send 128 traffic requests every 5 seconds.
2. We monitor the memory usage at 0.5-second intervals.
3. If we detect memory usage exceeding a predefined threshold, we then check the total number of records and halt the traffic transmission.