### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -17,7 +17,7 @@ jobs:
         TAG: ${{ github.ref }}
       run: |
         version=${TAG:10}
-        echo "::set-output name=version::$version"
+        echo "version=$version" >> $GITHUB_OUTPUT
 
   build-clickhouse-monitor:
     runs-on: [ubuntu-latest]

--- a/.github/workflows/process_release.yml
+++ b/.github/workflows/process_release.yml
@@ -40,7 +40,7 @@ jobs:
         TAG: ${{ github.ref }}
       run: |
         version=${TAG:10}
-        echo "::set-output name=version::$version"
+        echo "version=$version" >> $GITHUB_OUTPUT
     - name: Update Helm index with Theia archive
       uses: benc-uk/workflow-dispatch@v121
       with:


### PR DESCRIPTION
## Description

Closes #641 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=version::$version"
```

**TO-BE**

```yaml
echo "version=$version" >> $GITHUB_OUTPUT
```