### PR TITLE
Fix Grafana e2e test

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -121,7 +121,7 @@ var grafanaTestCases = []struct {
 			{
 				queryId:      11,
 				panelName:    "Number of NetworkPolicies",
-				expectResult: []string{"16"},
+				expectResult: []string{"10"},
 			},
 			{
 				queryId:      15,


### PR DESCRIPTION
In this PR we fix e2e test. We only apply these 10 np/anp in the flow-visibility e2e test:

test-flow-aggregator-networkpolicy-ingress-allow
test-flow-aggregator-networkpolicy-egress-allow
test-flow-aggregator-anp-ingress-reject
test-flow-aggregator-anp-ingress-drop
test-flow-aggregator-anp-egress-reject
test-flow-aggregator-anp-egress-drop
test-flow-aggregator-np-ingress-deny
test-flow-aggregator-np-egress-deny
test-flow-aggregator-antrea-networkpolicy-egress
test-flow-aggregator-antrea-networkpolicy-ingress

The e2e test keeps failing because it expects to see 16 networkpolicies in the home page instead of 10 networkpolicies.

Note:
This test has been passed for the previous 1 year. For some reason (unknown), we were expecting 16 web policies on the homepage.

![Screenshot 2023-12-11 at 4 04 03 PM](https://github.com/antrea-io/theia/assets/59460118/7c4cd697-71e6-4539-80d9-b1e3f289880e)
![Screenshot 2023-12-11 at 4 03 52 PM](https://github.com/antrea-io/theia/assets/59460118/b2ba4d28-8863-4e91-b8a0-a0ca73d755e8)


